### PR TITLE
Return correct ranges for hierarchical document symbol

### DIFF
--- a/server/src/document-symbol.ts
+++ b/server/src/document-symbol.ts
@@ -32,13 +32,21 @@ function collectDocumentSymbolsInRange(parent: tsp.NavigationTree, symbols: lsp.
                 }
             }
         }
+        let selectionRange = spanRange;
+        if (parent.nameSpan) {
+            const nameRange = asRange(parent.nameSpan);
+            // In the case of mergeable definitions, the nameSpan is only correct for the first definition.
+            if (Range.intersection(spanRange, nameRange)) {
+                selectionRange = nameRange;
+            }
+        }
         if (shouldInclude) {
             symbols.push({
                 name: parent.text,
                 detail: '',
                 kind: toSymbolKind(parent.kind),
-                range,
-                selectionRange: range,
+                range: spanRange,
+                selectionRange: selectionRange,
                 children
             });
         }

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -205,16 +205,23 @@ Box
         const symbols = await server.documentSymbol({
             textDocument: doc,
             position: lsp.Position.create(1, 1)
-        });
+        }) as lsp.DocumentSymbol[];
 
-        assert.equal(`
+        const expectation = `
 Foo
   foo
   myFunction
 Foo
   foo
   myFunction
-`, symbolsAsString(symbols) + '\n');
+`;
+        assert.equal(symbolsAsString(symbols) + '\n', expectation);
+        assert.deepEqual(symbols[0].selectionRange, {"start": {"line": 1, "character": 21}, "end": {"line": 1, "character": 24}});
+        assert.deepEqual(symbols[0].range, {"start": {"line": 1, "character": 8}, "end": {"line": 5, "character": 9}});
+
+        assert.deepEqual(symbols[1].selectionRange, symbols[1].range);
+        assert.deepEqual(symbols[1].range, {"start": {"line": 6, "character": 8}, "end": {"line": 10, "character": 9}});
+
     }).timeout(10000);
 });
 

--- a/server/src/protocol-translation.ts
+++ b/server/src/protocol-translation.ts
@@ -194,7 +194,7 @@ function toDocumentHighlightKind(kind: tsp.HighlightSpanKind): lsp.DocumentHighl
 
 export function asRange(span: tsp.TextSpan): lsp.Range {
     return lsp.Range.create(
-        Math.max(0, span.start.line - 1), Math.max(span.start.offset - 1, 0),
+        Math.max(0, span.start.line - 1), Math.max(0, span.start.offset - 1),
         Math.max(0, span.end.line - 1), Math.max(0, span.end.offset - 1)
     );
 }


### PR DESCRIPTION
- Pass the correct value for `range`
- Try to use `nameSpan` when possible for the value of `selectionRange`, which is only for definitions with a single span, and for the first the first span of definitions with multiple spans.