### PR TITLE
WIP - Get more detailed completions by default

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -15,6 +15,8 @@ const program = new Command('typescript-language-server')
     .version(require('../package.json').version)
     .option('--stdio', 'use stdio')
     .option('--node-ipc', 'use node-ipc')
+    .option('--detailed-completions', 'use detailed completions')
+    .option('--detailed-completions-limit <limit>', 'limit the number of completions provided with details. Defaults to `500`')
     .option('--log-level <logLevel>', 'A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.')
     .option('--socket <port>', 'use socket. example: --socket=5000')
     .option('--tsserver-log-file <tsserverLogFile>', 'Specify a tsserver log file. example: --tsserver-log-file ts-logs.txt')
@@ -32,6 +34,10 @@ if (program.tsserverLogFile && !program.tsserverLogVerbosity) {
   program.tsserverLogVerbosity = 'normal'
 }
 
+if (!program.detailedCompletionsLimit) {
+  program.detailedCompletionsLimit = 500
+}
+
 let logLevel = lsp.MessageType.Warning
 if (program.logLevel) {
     logLevel = parseInt(program.logLevel, 10);
@@ -45,5 +51,7 @@ createLspConnection({
     tsserverPath: program.tsserverPath as string,
     tsserverLogFile: program.tsserverLogFile as string,
     tsserverLogVerbosity: program.tsserverLogVerbosity as string,
-    showMessageLevel: logLevel as lsp.MessageType
+    showMessageLevel: logLevel as lsp.MessageType,
+    detailedCompletionsLimit: program.detailedCompletionsLimit,
+    detailedCompletions: program.detailedCompletions,
 }).listen();

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -145,6 +145,27 @@ export function asCommitCharacters(kind: ScriptElementKind): string[] | undefine
     return commitCharacters.length === 0 ? undefined : commitCharacters;
 }
 
+export function asDetailedCompletionItems(items: tsp.CompletionEntryDetails[], file: string, line: number, offset: number): TSCompletionItem[] {
+    return items.map(entry => {
+        const item: TSCompletionItem = {
+            label: entry.name,
+            kind: asCompletionItemKind(entry.kind),
+            commitCharacters: asCommitCharacters(entry.kind),
+            detail: asDetail(entry),
+            documentation: asDocumentation(entry),
+            data: {
+                file,
+                line,
+                offset,
+                entryNames: [
+                    entry.source ? { name: entry.name, source: entry.source.join(' ') } : entry.name
+                ]
+            }
+        }
+        return { ...item, ...asCodeActions(entry, file) }
+    })
+}
+
 export function asResolvedCompletionItem(item: TSCompletionItem, details: tsp.CompletionEntryDetails): TSCompletionItem {
     item.detail = asDetail(details);
     item.documentation = asDocumentation(details);

--- a/server/src/lsp-connection.ts
+++ b/server/src/lsp-connection.ts
@@ -16,7 +16,9 @@ export interface IServerOptions {
     tsserverPath: string;
     tsserverLogFile?: string;
     tsserverLogVerbosity?: string;
-    showMessageLevel: lsp.MessageType
+    showMessageLevel: lsp.MessageType;
+    detailedCompletionsLimit: number;
+    detailedCompletions: boolean;
 }
 
 export function createLspConnection(options: IServerOptions): lsp.IConnection {
@@ -28,7 +30,9 @@ export function createLspConnection(options: IServerOptions): lsp.IConnection {
         lspClient,
         tsserverPath: options.tsserverPath,
         tsserverLogFile: options.tsserverLogFile,
-        tsserverLogVerbosity: options.tsserverLogVerbosity
+        tsserverLogVerbosity: options.tsserverLogVerbosity,
+        detailedCompletions: options.detailedCompletions,
+        detailedCompletionsLimit: options.detailedCompletionsLimit,
     });
 
     connection.onInitialize(server.initialize.bind(server));

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -447,11 +447,10 @@ export class LspServer {
                 includeInsertTextCompletions: true
             }));
 
-            const body = result.body || [];
+            const body = (result.body || []).filter(entry => entry.kind !== 'warning');
 
             if (!this.options.detailedCompletions || body.length > this.options.detailedCompletionsLimit) {
                 return body
-                    .filter(entry => entry.kind !== 'warning')
                     .map(entry => asCompletionItem(entry, file, params.position, document));
             }
 

--- a/server/src/test-utils.ts
+++ b/server/src/test-utils.ts
@@ -67,6 +67,8 @@ export async function createServer(options: {
             applyWorkspaceEdit: () => Promise.reject(new Error('unsupported')),
             rename: () => Promise.reject(new Error('unsupported'))
         },
+        detailedCompletions: false,
+        detailedCompletionsLimit: 500,
     });
 
     await server.initialize({


### PR DESCRIPTION
Resolves #160 

Currently debugging why we require limiting the number of detailed completions. By limiting the number of detailed completions, we're somehow speeding up completion on even relatively small completion candidates. This lines up reports that Neovim is getting spammed with tons of completion responses that didn't seem necessary by @pyrho

Finally, I need to add a command line flag that disables detailed completions