### PR TITLE
Don't pass deprecated options to Completion request

### DIFF
--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -145,7 +145,7 @@ function asCommitCharacters(kind: ScriptElementKind): string[] | undefined {
     return commitCharacters.length === 0 ? undefined : commitCharacters;
 }
 
-export function asResolvedCompletionItem(item: TSCompletionItem, details: tsp.CompletionEntryDetails): TSCompletionItem {
+export function asResolvedCompletionItem(item: lsp.CompletionItem, details: tsp.CompletionEntryDetails): lsp.CompletionItem {
     item.detail = asDetail(details);
     item.documentation = asDocumentation(details);
     Object.assign(item, asCodeActions(details, item.data.file));

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -12,7 +12,7 @@ import { ScriptElementKind } from './tsp-command-types';
 import { asRange, toTextEdit, asPlainText, asDocumentation } from './protocol-translation';
 import { Commands } from './commands';
 
-export interface TSCompletionItem extends lsp.CompletionItem {
+interface TSCompletionItem extends lsp.CompletionItem {
     data: tsp.CompletionDetailsRequestArgs;
 }
 

--- a/server/src/lsp-server.spec.ts
+++ b/server/src/lsp-server.spec.ts
@@ -10,7 +10,6 @@ import * as lsp from 'vscode-languageserver/node';
 import * as lspcalls from './lsp-protocol.calls.proposed';
 import { LspServer } from './lsp-server';
 import { uri, createServer, position, lastPosition, filePath, getDefaultClientCapabilities, positionAfter } from './test-utils';
-import { TSCompletionItem } from './completion';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 const assert = chai.assert;

--- a/server/src/lsp-server.ts
+++ b/server/src/lsp-server.ts
@@ -28,7 +28,7 @@ import {
 } from './protocol-translation';
 import { getTsserverExecutable } from './utils';
 import { LspDocuments, LspDocument } from './document';
-import { asCompletionItem, TSCompletionItem, asResolvedCompletionItem } from './completion';
+import { asCompletionItem, asResolvedCompletionItem } from './completion';
 import { asSignatureHelp } from './hover';
 import { Commands } from './commands';
 import { provideQuickFix } from './quickfix';

--- a/server/src/test-utils.ts
+++ b/server/src/test-utils.ts
@@ -58,6 +58,10 @@ export function position(document: lsp.TextDocumentItem, match: string): lsp.Pos
     return positionAt(document, document.text.indexOf(match));
 }
 
+export function positionAfter(document: lsp.TextDocumentItem, match: string): lsp.Position {
+    return positionAt(document, document.text.indexOf(match) + match.length);
+}
+
 export function lastPosition(document: lsp.TextDocumentItem, match: string): lsp.Position {
     return positionAt(document, document.text.lastIndexOf(match));
 }


### PR DESCRIPTION
The deprecated options "includeExternalModuleExports" and "includeInsertTextCompletions" are now passed as global, non-deprecated typescript preferences.

To achieve that, added those as default preferences to the preferences object that the user can override.

Also switch to non-deprecated "CompletionInfo" request and handle "isIncomplete" flag (it is used when suggesting global import completions when `includeCompletionsForImportStatements` and `includeCompletionsWithInsertText` typescript preferences are enabled) and fix some Completion-related types (use LSP types instead of TSC types).

@apexskier 