### PR TITLE
Fix Windows path regression introduced in #220

### DIFF
--- a/src/protocol-translation.ts
+++ b/src/protocol-translation.ts
@@ -19,15 +19,13 @@ export function uriToPath(stringUri: string): string | undefined {
 }
 
 function parsePathOrUri(filepath: string): URI {
-    try {
-        // handles valid URIs from yarn pnp, will error if doesn't have scheme
-        // zipfile:/foo/bar/baz.zip::path/to/module
+    // handles valid URIs from yarn pnp, will error if doesn't have scheme
+    // zipfile:/foo/bar/baz.zip::path/to/module
+    if (filepath.startsWith('zipfile:')) {
         return URI.parse(filepath);
-    } catch {
-        // handles valid filepaths from everything else
-        // /path/to/module
-        return URI.file(filepath);
     }
+    // handles valid filepaths from everything else /path/to/module
+    return URI.file(filepath);
 }
 
 export function pathToUri(filepath: string, documents: LspDocuments | undefined): string {


### PR DESCRIPTION
The Windows paths like "C:\\foo" will not cause "URI.parse" to throw
but instead will create an invalid URI. Change to code to only use
URI.parse for zipfile: paths specifically.