### PR TITLE
Send diagnostics even to clients that don't signal support

### DIFF
--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -20,7 +20,7 @@ class FileDiagnostics {
         protected readonly uri: string,
         protected readonly publishDiagnostics: (params: lsp.PublishDiagnosticsParams) => void,
         protected readonly documents: LspDocuments,
-        protected readonly publishDiagnosticsCapabilities: NonNullable<lsp.TextDocumentClientCapabilities['publishDiagnostics']>
+        protected readonly publishDiagnosticsCapabilities: lsp.TextDocumentClientCapabilities['publishDiagnostics']
     ) { }
 
     update(kind: EventTypes, diagnostics: tsp.Diagnostic[]): void {
@@ -49,7 +49,7 @@ export class DiagnosticEventQueue {
     constructor(
         protected readonly publishDiagnostics: (params: lsp.PublishDiagnosticsParams) => void,
         protected readonly documents: LspDocuments,
-        protected readonly publishDiagnosticsCapabilities: NonNullable<lsp.TextDocumentClientCapabilities['publishDiagnostics']>,
+        protected readonly publishDiagnosticsCapabilities: lsp.TextDocumentClientCapabilities['publishDiagnostics'],
         protected readonly logger: Logger
     ) { }
 

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -913,7 +913,7 @@ describe('diagnostics (no client support)', () => {
         });
     });
 
-    it('no diagnostics are published', async () => {
+    it('diagnostics are published', async () => {
         const doc = {
             uri: uri('diagnosticsBar.ts'),
             languageId: 'typescript',
@@ -931,6 +931,7 @@ describe('diagnostics (no client support)', () => {
         await server.requestDiagnostics();
         await new Promise(resolve => setTimeout(resolve, 200));
         const resultsForFile = diagnostics.get(doc.uri);
-        assert.isUndefined(resultsForFile, 'Unexpected diagnostics received');
+        assert.isDefined(resultsForFile);
+        assert.strictEqual(resultsForFile?.diagnostics.length, 1);
     }).timeout(10000);
 });

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -95,15 +95,12 @@ export class LspServer {
     async initialize(params: TypeScriptInitializeParams): Promise<TypeScriptInitializeResult> {
         this.logger.log('initialize', params);
         this.initializeParams = params;
-
-        if (this.initializeParams.capabilities.textDocument?.publishDiagnostics) {
-            this.diagnosticQueue = new DiagnosticEventQueue(
-                diagnostics => this.options.lspClient.publishDiagnostics(diagnostics),
-                this.documents,
-                this.initializeParams.capabilities.textDocument.publishDiagnostics,
-                this.logger
-            );
-        }
+        this.diagnosticQueue = new DiagnosticEventQueue(
+            diagnostics => this.options.lspClient.publishDiagnostics(diagnostics),
+            this.documents,
+            this.initializeParams.capabilities.textDocument?.publishDiagnostics,
+            this.logger
+        );
 
         const userInitializationOptions: TypeScriptInitializationOptions = this.initializeParams.initializationOptions || {};
         const { hostInfo, maxTsServerMemory } = userInitializationOptions;

--- a/src/protocol-translation.ts
+++ b/src/protocol-translation.ts
@@ -121,7 +121,7 @@ function toDiagnosticSeverity(category: string): lsp.DiagnosticSeverity {
 export function toDiagnostic(
     diagnostic: tsp.Diagnostic,
     documents: LspDocuments | undefined,
-    publishDiagnosticsCapabilities: NonNullable<lsp.TextDocumentClientCapabilities['publishDiagnostics']>
+    publishDiagnosticsCapabilities: lsp.TextDocumentClientCapabilities['publishDiagnostics']
 ): lsp.Diagnostic {
     const lspDiagnostic: lsp.Diagnostic = {
         range: {
@@ -134,7 +134,7 @@ export function toDiagnostic(
         source: diagnostic.source || 'typescript',
         relatedInformation: asRelatedInformation(diagnostic.relatedInformation, documents)
     };
-    if (publishDiagnosticsCapabilities.tagSupport) {
+    if (publishDiagnosticsCapabilities?.tagSupport) {
         lspDiagnostic.tags = getDiagnosticTags(diagnostic);
     }
     return lspDiagnostic;


### PR DESCRIPTION
Apparently the diagnostics existed before the publishDiagnostics
capability so it's correct to send those in all cases.

Reverts #229