### PR TITLE
Add workspace/configuration

### DIFF
--- a/src/lsp-connection.ts
+++ b/src/lsp-connection.ts
@@ -20,8 +20,9 @@ export interface IServerOptions {
     showMessageLevel: lsp.MessageType;
 }
 
+export const connection = lsp.createConnection(lsp.ProposedFeatures.all);
+
 export function createLspConnection(options: IServerOptions): lsp.Connection {
-    const connection = lsp.createConnection(lsp.ProposedFeatures.all);
     const lspClient = new LspClientImpl(connection);
     const logger = new LspClientLogger(lspClient, options.showMessageLevel);
     const server: LspServer = new LspServer({

--- a/src/lsp-protocol.inlayHints.proposed.ts
+++ b/src/lsp-protocol.inlayHints.proposed.ts
@@ -1,5 +1,5 @@
 import * as lsp from 'vscode-languageserver/node';
-import tsp from 'typescript/lib/protocol';
+import tsp, { UserPreferences } from 'typescript/lib/protocol';
 import { RequestHandler } from 'vscode-jsonrpc';
 
 export type InlayHintsParams = {
@@ -28,3 +28,14 @@ export type InlayHintsResult = {
 export const type = new lsp.RequestType<InlayHintsParams, InlayHintsResult, lsp.TextDocumentRegistrationOptions>('typescript/inlayHints');
 
 export type HandlerSignature = RequestHandler<InlayHintsParams, InlayHintsResult | null, void>;
+
+
+export interface InlayHintsOptions extends UserPreferences {
+    includeInlayParameterNameHints: "none" | "literals" | "all";
+    includeInlayParameterNameHintsWhenArgumentMatchesName: boolean;
+    includeInlayFunctionParameterTypeHints: boolean,
+    includeInlayVariableTypeHints: boolean;
+    includeInlayPropertyDeclarationTypeHints: boolean;
+    includeInlayFunctionLikeReturnTypeHints: boolean;
+    includeInlayEnumMemberValueHints: boolean;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { TextDocument } from "vscode-languageserver-textdocument";
+
 /*
  * Copyright (C) 2017, 2018 TypeFox and others.
  *
@@ -21,4 +23,12 @@ export function getTsserverExecutable(): string {
 
 function isWindows(): boolean {
     return /^win/.test(process.platform);
+}
+
+export function getConfigKey<ConfigKey extends string>(configKey: ConfigKey, textDocument: TextDocument) : `typescript.${ConfigKey}` | `javascript.${ConfigKey}` {
+    return isTypeScriptDocument(textDocument) ? `typescript.${configKey}` : `javascript.${configKey}`
+}
+
+function isTypeScriptDocument(textDocument: TextDocument) {
+    return ['typescript', 'typescriptreact'].includes(textDocument.languageId);
 }


### PR DESCRIPTION
This allows the server to ask the client for a configuration.

```jsonc
{
	"initializationOptions": {
		"preferences": {
			// previously only this was exposed to customize inlay hints
			// you could not turn off inlay hints for JS withouth turn the off for TS
			"includeInlayEnumMemberValueHints": true,
			"includeInlayFunctionLikeReturnTypeHints": true,
			"includeInlayFunctionParameterTypeHints": true,
			"includeInlayParameterNameHints": "all",
			"includeInlayParameterNameHintsWhenArgumentMatchesName": true,
			"includeInlayPropertyDeclarationTypeHints": true,
			"includeInlayVariableTypeHints": true,
		}
	},
	"settings": {
		// now this PR allows specifying for each language separate configuration
		"typescript.inlayHints.includeInlayEnumMemberValueHints": true,
		"typescript.inlayHints.includeInlayFunctionLikeReturnTypeHints": true,
		"typescript.inlayHints.includeInlayFunctionParameterTypeHints": true,
		"typescript.inlayHints.includeInlayParameterNameHints": "all",
		"typescript.inlayHints.includeInlayParameterNameHintsWhenArgumentMatchesName": true,
		"typescript.inlayHints.includeInlayPropertyDeclarationTypeHints": true,
		"typescript.inlayHints.includeInlayVariableTypeHints": true,

		"javascript.inlayHints.includeInlayEnumMemberValueHints": true,
		"javascript.inlayHints.includeInlayFunctionLikeReturnTypeHints": true,
		"javascript.inlayHints.includeInlayFunctionParameterTypeHints": true,
		"javascript.inlayHints.includeInlayParameterNameHints": "all",
		"javascript.inlayHints.includeInlayParameterNameHintsWhenArgumentMatchesName": true,
		"javascript.inlayHints.includeInlayPropertyDeclarationTypeHints": true,
		"javascript.inlayHints.includeInlayVariableTypeHints": true,
	}
}
```

### Why?

Thiea added inlay hints and there is no way disable inlay hints in JavaScript without disabling them in TypeScript.
This PR allows for that.

----
This is still a draft and I have some suggestions.