### PR TITLE
feat: include import specifier for import completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ typescript-language-server --stdio
   Options:
 
     -V, --version                          output the version number
-    --stdio                                use stdio (the only supported and required option)
+    --stdio                                use stdio (required option)
     --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.
     --tsserver-log-file <tsServerLogFile>  Specify a tsserver log file. example: --tsserver-log-file=ts-logs.txt
     --tsserver-log-verbosity <verbosity>   Specify tsserver log verbosity (off, terse, normal, verbose). Defaults to `normal`. example: --tsserver-log-verbosity=verbose
@@ -83,6 +83,10 @@ interface UserPreferences {
      * values, with insertion text to replace preceding `.` tokens with `?.`.
      */
     includeAutomaticOptionalChainCompletions: boolean;
+    /**
+     * Allows import module names to be resolved in the initial completions request.
+     * @default false
+     */
     allowIncompleteCompletions: boolean;
     importModuleSpecifierPreference: "shortest" | "project-relative" | "relative" | "non-relative";
     /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
@@ -93,6 +97,11 @@ interface UserPreferences {
     provideRefactorNotApplicableReason: boolean;
     allowRenameOfImportPath: boolean;
     includePackageJsonAutoImports: "auto" | "on" | "off";
+    /**
+     * Requires "includeCompletionsWithSnippetText" to be enabled.
+     * @default "none"
+     */
+    jsxAttributeCompletionStyle: "auto" | "braces" | "none";
     displayPartsForJSDoc: boolean;
     generateReturnInDocTemplate: boolean;
 }
@@ -102,8 +111,15 @@ From the `preferences` options listed above, this server explicilty sets the fol
 
 ```js
 {
-  includeCompletionsForModuleExports: true,
-  includeCompletionsWithInsertText: true,
+    allowIncompleteCompletions: true,
+    allowRenameOfImportPath: true,
+    displayPartsForJSDoc: true,
+    generateReturnInDocTemplate: true,
+    includeAutomaticOptionalChainCompletions: true,
+    includeCompletionsForImportStatements: true,
+    includeCompletionsForModuleExports: true,
+    includeCompletionsWithInsertText: true,
+    includeCompletionsWithSnippetText: true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ From the `preferences` options listed above, this server explicilty sets the fol
 
 ```js
 {
+    allowIncompleteCompletions: true,
+    allowTextChangesInNewFiles: true,
     includeCompletionsForModuleExports: true,
     includeCompletionsWithInsertText: true,
 }

--- a/README.md
+++ b/README.md
@@ -97,11 +97,6 @@ interface UserPreferences {
     provideRefactorNotApplicableReason: boolean;
     allowRenameOfImportPath: boolean;
     includePackageJsonAutoImports: "auto" | "on" | "off";
-    /**
-     * Requires "includeCompletionsWithSnippetText" to be enabled.
-     * @default "none"
-     */
-    jsxAttributeCompletionStyle: "auto" | "braces" | "none";
     displayPartsForJSDoc: boolean;
     generateReturnInDocTemplate: boolean;
 }
@@ -111,15 +106,8 @@ From the `preferences` options listed above, this server explicilty sets the fol
 
 ```js
 {
-    allowIncompleteCompletions: true,
-    allowRenameOfImportPath: true,
-    displayPartsForJSDoc: true,
-    generateReturnInDocTemplate: true,
-    includeAutomaticOptionalChainCompletions: true,
-    includeCompletionsForImportStatements: true,
     includeCompletionsForModuleExports: true,
     includeCompletionsWithInsertText: true,
-    includeCompletionsWithSnippetText: true,
 }
 ```
 

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -147,6 +147,10 @@ export class LspServer {
         this.tspClient.start();
         this.tspClient.request(CommandTypes.Configure, {
             ...hostInfo ? { hostInfo } : {},
+            formatOptions: {
+                // We can use \n here since the editor should normalize later on to its line endings.
+                newLineCharacter: '\n'
+            },
             preferences: {
                 allowTextChangesInNewFiles: true,
                 ...preferences

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -111,6 +111,8 @@ export class LspServer {
             logVerbosity: userInitializationOptions.logVerbosity || this.options.tsserverLogVerbosity,
             plugins: userInitializationOptions.plugins || [],
             preferences: {
+                allowIncompleteCompletions: true,
+                allowTextChangesInNewFiles: true,
                 includeCompletionsForModuleExports: true,
                 includeCompletionsWithInsertText: true,
                 ...userInitializationOptions.preferences
@@ -144,10 +146,7 @@ export class LspServer {
                 // We can use \n here since the editor should normalize later on to its line endings.
                 newLineCharacter: '\n'
             },
-            preferences: {
-                allowTextChangesInNewFiles: true,
-                ...preferences
-            }
+            preferences
         });
 
         this.tspClient.request(CommandTypes.CompilerOptionsForInferredProjects, {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -111,15 +111,8 @@ export class LspServer {
             logVerbosity: userInitializationOptions.logVerbosity || this.options.tsserverLogVerbosity,
             plugins: userInitializationOptions.plugins || [],
             preferences: {
-                allowIncompleteCompletions: true,
-                allowRenameOfImportPath: true,
-                displayPartsForJSDoc: true,
-                generateReturnInDocTemplate: true,
-                includeAutomaticOptionalChainCompletions: true,
-                includeCompletionsForImportStatements: true,
                 includeCompletionsForModuleExports: true,
                 includeCompletionsWithInsertText: true,
-                includeCompletionsWithSnippetText: true,
                 ...userInitializationOptions.preferences
             }
         };

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -111,8 +111,15 @@ export class LspServer {
             logVerbosity: userInitializationOptions.logVerbosity || this.options.tsserverLogVerbosity,
             plugins: userInitializationOptions.plugins || [],
             preferences: {
+                allowIncompleteCompletions: true,
+                allowRenameOfImportPath: true,
+                displayPartsForJSDoc: true,
+                generateReturnInDocTemplate: true,
+                includeAutomaticOptionalChainCompletions: true,
+                includeCompletionsForImportStatements: true,
                 includeCompletionsForModuleExports: true,
                 includeCompletionsWithInsertText: true,
+                includeCompletionsWithSnippetText: true,
                 ...userInitializationOptions.preferences
             }
         };

--- a/src/tsp-command-types.ts
+++ b/src/tsp-command-types.ts
@@ -173,3 +173,25 @@ export enum ScriptElementKind {
     /** Jsdoc @link: in `{@link C link text}`, the link text "link text" */
     linkText = 'link text'
 }
+
+export class KindModifiers {
+    public static readonly optional = 'optional';
+    public static readonly deprecated = 'deprecated';
+    public static readonly color = 'color';
+
+    public static readonly dtsFile = '.d.ts';
+    public static readonly tsFile = '.ts';
+    public static readonly tsxFile = '.tsx';
+    public static readonly jsFile = '.js';
+    public static readonly jsxFile = '.jsx';
+    public static readonly jsonFile = '.json';
+
+    public static readonly fileExtensionKindModifiers = [
+        KindModifiers.dtsFile,
+        KindModifiers.tsFile,
+        KindModifiers.tsxFile,
+        KindModifiers.jsFile,
+        KindModifiers.jsxFile,
+        KindModifiers.jsonFile
+    ];
+}


### PR DESCRIPTION
For completions that import from another package, the completions
will include a "detail" field with the name of the module.

Also aligned some other logic with the typescript language services used in VSCode:
 - annotate the completions with the local name of the import when
   completing a path in `import foo from '...'`
 - update completion `sortText` regardless if the completion "isRecommended"

Fixes #280

### Before
![Screenshot 2021-11-08 at 20 27 39](https://user-images.githubusercontent.com/153197/140805208-cfff526f-9a80-48fa-9a09-9ac40fef61b4.png)

### After
![Screenshot 2021-11-08 at 20 49 34](https://user-images.githubusercontent.com/153197/140808157-048bb1b8-9c5a-4ec3-acdb-a94249c624e6.png)


