### PR TITLE
feat: announce support for "source.organizeImports.ts-ls" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Based on concepts and ideas from https://github.com/prabirshrestha/typescript-la
 
 Maintained by a [community of contributors](https://github.com/typescript-language-server/typescript-language-server/graphs/contributors) like you
 
-# Installing
+## Installing
 
 ```sh
 npm install -g typescript-language-server
 ```
 
-# Running the language server
+## Running the language server
 
 ```
 typescript-language-server --stdio
@@ -154,58 +154,53 @@ Some of the preferences can be controlled through the `workspace/didChangeConfig
 [language].inlayHints.includeInlayVariableTypeHints: boolean;
 ```
 
-# Supported Protocol features
+## Code actions on save
 
-- [x] textDocument/didChange (incremental)
-- [x] textDocument/didClose
-- [x] textDocument/didOpen
-- [x] textDocument/didSave
+Server announces support for the `source.organizeImports.ts-ls` code action which allows editors that support running code actions on save to automatically organize imports on saving. The user can enable it with a setting similar to (can vary per-editor):
 
-- [x] textDocument/codeAction
-- [x] textDocument/completion (incl. completion/resolve)
-- [x] textDocument/definition
-- [x] textDocument/documentHighlight
-- [x] textDocument/documentSymbol
-- [x] textDocument/executeCommand
-- [x] textDocument/formatting
-- [x] textDocument/rangeFormatting
-- [x] textDocument/hover
-- [x] textDocument/rename
-- [x] textDocument/references
-- [x] textDocument/signatureHelp
-- [x] workspace/symbol
-- [x] workspace/didChangeConfiguration
-- [x] [workspace/executeCommand](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workspace_executeCommand)
+```js
+"codeActionsOnSave": {
+    "source.organizeImports": true,
+    // or
+    "source.organizeImports.ts-ls": true,
+}
+```
 
-    Most of the time, you'll execute commands with arguments retrieved from another request like `textDocument/codeAction`. There are some use cases for calling them manually.
+## Workspace commands (`workspace/executeCommand`)
 
-    Supported commands:
+See [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workspace_executeCommand).
 
-    `lsp` refers to the language server protocol, `tsp` refers to the typescript server protocol.
+Most of the time, you'll execute commands with arguments retrieved from another request like `textDocument/codeAction`. There are some use cases for calling them manually.
 
-    * `_typescript.applyWorkspaceEdit`
-        ```ts
-        type Arguments = [lsp.WorkspaceEdit]
-        ```
-    * `_typescript.applyCodeAction`
-        ```ts
-        type Arguments = [tsp.CodeAction]
-        ```
-    * `_typescript.applyRefactoring`
-        ```ts
-        type Arguments = [tsp.GetEditsForRefactorRequestArgs]
-        ```
-    * `_typescript.organizeImports`
-        ```ts
-        // The "skipDestructiveCodeActions" argument is supported from Typescript 4.4+
-        type Arguments = [string] | [string, { skipDestructiveCodeActions?: boolean }]
-        ```
-    * `_typescript.applyRenameFile`
-        ```ts
-        type Arguments = [{ sourceUri: string; targetUri: string; }]
-        ```
+Supported commands:
 
-## `typescript/inlayHints` (experimental, supported from Typescript v4.4.2)
+`lsp` refers to the language server protocol, `tsp` refers to the typescript server protocol.
+
+* `_typescript.applyWorkspaceEdit`
+    ```ts
+    type Arguments = [lsp.WorkspaceEdit]
+    ```
+* `_typescript.applyCodeAction`
+    ```ts
+    type Arguments = [tsp.CodeAction]
+    ```
+* `_typescript.applyRefactoring`
+    ```ts
+    type Arguments = [tsp.GetEditsForRefactorRequestArgs]
+    ```
+* `_typescript.organizeImports`
+    ```ts
+    // The "skipDestructiveCodeActions" argument is supported from Typescript 4.4+
+    type Arguments = [string] | [string, { skipDestructiveCodeActions?: boolean }]
+    ```
+* `_typescript.applyRenameFile`
+    ```ts
+    type Arguments = [{ sourceUri: string; targetUri: string; }]
+    ```
+
+## Inlay hints (`typescript/inlayHints`) (experimental)
+
+Supports experimental inline hints.
 
 ```ts
 type Request = {
@@ -241,7 +236,9 @@ export interface InlayHintsOptions extends UserPreferences {
 }
 ```
 
-## `textDocument/calls` (experimental)
+## Callers and callees (`textDocument/calls`) (experimental)
+
+Supports showing callers and calles for a given symbol. If the editor has support for appropriate UI, it can generate a tree of callers and calles for a document.
 
 ```ts
 type Request = {
@@ -323,7 +320,31 @@ interface DefinitionSymbol {
 }
 ```
 
-# Development
+## Supported Protocol features
+
+- [x] textDocument/didChange (incremental)
+- [x] textDocument/didClose
+- [x] textDocument/didOpen
+- [x] textDocument/didSave
+- [x] textDocument/codeAction
+- [x] textDocument/completion (incl. completion/resolve)
+- [x] textDocument/definition
+- [x] textDocument/documentHighlight
+- [x] textDocument/documentSymbol
+- [x] textDocument/executeCommand
+- [x] textDocument/formatting
+- [x] textDocument/rangeFormatting
+- [x] textDocument/hover
+- [x] textDocument/rename
+- [x] textDocument/references
+- [x] textDocument/signatureHelp
+- [x] textDocument/calls (experimental)
+- [x] typescript/inlayHints (experimental, supported from Typescript v4.4.2)
+- [x] workspace/symbol
+- [x] workspace/didChangeConfiguration
+- [x] workspace/executeCommand
+
+## Development
 
 ### Build
 
@@ -331,7 +352,7 @@ interface DefinitionSymbol {
 yarn
 ```
 
-## Test
+### Test
 
 ```sh
 yarn test

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,3 +15,7 @@ export const Commands = {
     /** Commands below should be implemented by the client */
     SELECT_REFACTORING: '_typescript.selectRefactoring'
 };
+
+export const CodeActions = {
+    SourceOrganizeImportsTsLs: 'source.organizeImports.ts-ls'
+};

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -11,6 +11,7 @@ import * as lspcalls from './lsp-protocol.calls.proposed';
 import { LspServer } from './lsp-server';
 import { uri, createServer, position, lastPosition, filePath, getDefaultClientCapabilities, positionAfter } from './test-utils';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { CodeActions } from './commands';
 
 const assert = chai.assert;
 
@@ -829,7 +830,7 @@ describe('code actions', () => {
                     code: 6133,
                     message: 'unused arg'
                 }],
-                only: ['source.organizeImports']
+                only: [CodeActions.SourceOrganizeImportsTsLs]
             }
         }))!;
 
@@ -863,13 +864,13 @@ existsSync('t');`
                     code: 6133,
                     message: 'unused arg'
                 }],
-                only: ['source.organizeImports']
+                only: [CodeActions.SourceOrganizeImportsTsLs]
             }
         }))!;
 
         assert.deepEqual(result, [
             {
-                kind: 'source.organizeImports',
+                kind: CodeActions.SourceOrganizeImportsTsLs,
                 title: 'Organize imports',
                 edit: {
                     documentChanges: [

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -31,7 +31,7 @@ import { getTsserverExecutable } from './utils';
 import { LspDocuments, LspDocument } from './document';
 import { asCompletionItem, asResolvedCompletionItem } from './completion';
 import { asSignatureHelp } from './hover';
-import { Commands } from './commands';
+import { CodeActions, Commands } from './commands';
 import { provideQuickFix } from './quickfix';
 import { provideRefactors } from './refactor';
 import { provideOrganizeImports } from './organize-imports';
@@ -168,7 +168,9 @@ export class LspServer {
                     triggerCharacters: ['.', '"', '\'', '/', '@', '<'],
                     resolveProvider: true
                 },
-                codeActionProvider: true,
+                codeActionProvider: {
+                    codeActionKinds: [CodeActions.SourceOrganizeImportsTsLs]
+                },
                 definitionProvider: true,
                 documentFormattingProvider: true,
                 documentRangeFormattingProvider: true,
@@ -718,7 +720,7 @@ export class LspServer {
         }
 
         // organize import is provided by tsserver for any line, so we only get it if explicitly requested
-        if (params.context.only?.includes(CodeActionKind.SourceOrganizeImports)) {
+        if (params.context.only?.includes(CodeActions.SourceOrganizeImportsTsLs)) {
             // see this issue for more context about how this argument is used
             // https://github.com/microsoft/TypeScript/issues/43051
             const skipDestructiveCodeActions = params.context.diagnostics.some(

--- a/src/organize-imports.spec.ts
+++ b/src/organize-imports.spec.ts
@@ -2,6 +2,7 @@ import tsp from 'typescript/lib/protocol';
 import * as chai from 'chai';
 import { provideOrganizeImports } from './organize-imports';
 import { filePath, uri } from './test-utils';
+import { CodeActions } from './commands';
 
 describe('provideOrganizeImports', () => {
     it('converts tsserver response to lsp code actions', () => {
@@ -17,7 +18,7 @@ describe('provideOrganizeImports', () => {
         const actual = provideOrganizeImports(response as any as tsp.OrganizeImportsResponse, undefined);
         const expected = [{
             title: 'Organize imports',
-            kind: 'source.organizeImports',
+            kind: CodeActions.SourceOrganizeImportsTsLs,
             edit: {
                 documentChanges: [
                     {

--- a/src/organize-imports.ts
+++ b/src/organize-imports.ts
@@ -9,7 +9,7 @@ import * as lsp from 'vscode-languageserver/node';
 import tsp from 'typescript/lib/protocol';
 import { toTextDocumentEdit } from './protocol-translation';
 import { LspDocuments } from './document';
-import { CodeActionKind } from 'vscode-languageserver/node';
+import { CodeActions } from './commands';
 
 export function provideOrganizeImports(response: tsp.OrganizeImportsResponse | undefined, documents: LspDocuments | undefined): Array<lsp.CodeAction> {
     if (!response || response.body.length === 0) {
@@ -20,6 +20,6 @@ export function provideOrganizeImports(response: tsp.OrganizeImportsResponse | u
         lsp.CodeAction.create(
             'Organize imports',
             { documentChanges: response.body.map(edit => toTextDocumentEdit(edit, documents)) },
-            CodeActionKind.SourceOrganizeImports
+            CodeActions.SourceOrganizeImportsTsLs
         )];
 }


### PR DESCRIPTION
Announcing support for that code action allows editors that support
running code actions on save to automatically run the code action if
the user has configured the editor with settings like

```js
  "codeActionsOnSave": {
    "source.organizeImports": true,
    // or
    "source.organizeImports.ts-ls": true,
  },
```