### PR TITLE
feat: update default typescript options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,15 @@ From the `preferences` options listed above, this server explicilty sets the fol
 ```js
 {
     allowIncompleteCompletions: true,
+    allowRenameOfImportPath: true,
     allowTextChangesInNewFiles: true,
+    displayPartsForJSDoc: true,
+    generateReturnInDocTemplate: true,
+    includeAutomaticOptionalChainCompletions: true,
+    includeCompletionsForImportStatements: true,
     includeCompletionsForModuleExports: true,
     includeCompletionsWithInsertText: true,
+    includeCompletionsWithSnippetText: true,
 }
 ```
 

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -112,9 +112,15 @@ export class LspServer {
             plugins: userInitializationOptions.plugins || [],
             preferences: {
                 allowIncompleteCompletions: true,
+                allowRenameOfImportPath: true,
                 allowTextChangesInNewFiles: true,
+                displayPartsForJSDoc: true,
+                generateReturnInDocTemplate: true,
+                includeAutomaticOptionalChainCompletions: true,
+                includeCompletionsForImportStatements: true,
                 includeCompletionsForModuleExports: true,
                 includeCompletionsWithInsertText: true,
+                includeCompletionsWithSnippetText: true,
                 ...userInitializationOptions.preferences
             }
         };


### PR DESCRIPTION
Set the following additional options by default:

    allowRenameOfImportPath: true,
    displayPartsForJSDoc: true,
    generateReturnInDocTemplate: true,
    includeAutomaticOptionalChainCompletions: true,
    includeCompletionsForImportStatements: true,
    includeCompletionsWithSnippetText: true,

This aligns more with the default options of the typescript language
services in VSCode.