### PR TITLE
fix: change default log level from "warn" to "info"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ typescript-language-server --stdio
 
     -V, --version                          output the version number
     --stdio                                use stdio (required option)
-    --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.
+    --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `3`.
     --tsserver-log-file <tsServerLogFile>  Specify a tsserver log file. example: --tsserver-log-file=ts-logs.txt
     --tsserver-log-verbosity <verbosity>   Specify tsserver log verbosity (off, terse, normal, verbose). Defaults to `normal`. example: --tsserver-log-verbosity=verbose
     --tsserver-path <path>                 Specify path to tsserver. example: --tsserver-path=tsserver

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ import { getTsserverExecutable } from './utils';
 import { createLspConnection } from './lsp-connection';
 import * as lsp from 'vscode-languageserver/node';
 
+const DEFAULT_LOG_LEVEL = lsp.MessageType.Info;
+
 const program = new Command('typescript-language-server')
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     .version(require('../package.json').version)
@@ -28,12 +30,12 @@ if (options.tsserverLogFile && !options.tsserverLogVerbosity) {
     options.tsserverLogVerbosity = 'normal';
 }
 
-let logLevel = lsp.MessageType.Warning;
+let logLevel = DEFAULT_LOG_LEVEL;
 if (options.logLevel) {
     logLevel = parseInt(options.logLevel, 10);
     if (logLevel && (logLevel < 1 || logLevel > 4)) {
         console.error(`Invalid '--log-level ${logLevel}'. Falling back to 'info' level.`);
-        logLevel = lsp.MessageType.Warning;
+        logLevel = DEFAULT_LOG_LEVEL;
     }
 }
 

--- a/src/tsp-client.ts
+++ b/src/tsp-client.ts
@@ -103,7 +103,7 @@ export class TspClient {
         }
         this.cancellationPipeName = tempy.file({ name: 'tscancellation' });
         args.push('--cancellationPipeName', `${this.cancellationPipeName}*`);
-        this.logger.info(`Starting tsserver : '${tsserverPath} ${args.join(' ')}'`);
+        this.logger.log(`Starting tsserver : '${tsserverPath} ${args.join(' ')}'`);
         const tsserverPathIsModule = path.extname(tsserverPath) === '.js';
         const options = {
             silent: true,


### PR DESCRIPTION
We want to be able to notify the user about some things without
having to use an error-like messages.

This will come useful in later PR that adds information about used
typescript version.