### PR TITLE
fix: add missing semver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "commander": "^7.2.0",
     "fs-extra": "^10.0.0",
     "p-debounce": "^2.1.0",
+    "semver": "^7.3.5",
     "tempy": "^1.0.1",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-protocol": "^3.16.0",


### PR DESCRIPTION
This PR fixes a bug in 0.7.0 that prevents `typescript-language-server` from starting due to the `semver` package not being defined as a dependency:

```sh
09:39 $ typescript-language-server --stdio
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'semver'
Require stack:
- /home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/utils/api.js
- /home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/lsp-server.js
- /home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/lsp-connection.js
- /home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/cli.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:94:18)
    at Object.<anonymous> (/home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/utils/api.js:26:29)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/utils/api.js',
    '/home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/lsp-server.js',
    '/home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/lsp-connection.js',
    '/home/ubuntu/.nvm/versions/node/v16.8.0/lib/node_modules/typescript-language-server/lib/cli.js'
  ]
}
```

As far as I saw, this is because `semver` used in https://github.com/typescript-language-server/typescript-language-server/blob/fbf72dda58df6d485d86a7d38e8d64fc3903ea46/src/utils/api.ts#L6 is not listed in the packages' `dependencies` https://github.com/typescript-language-server/typescript-language-server/blob/814fb0d215c41a98842c077019e587a9cd57611e/package.json#L20-L30

Looking at `yarn.lock`, `semver` is a transitive dependency that was installed thanks to `@typescript-eslint` tooling:
https://github.com/typescript-language-server/typescript-language-server/blob/c180b0744bf74e9352be93a56c3905e59ea79cad/yarn.lock#L162
https://github.com/typescript-language-server/typescript-language-server/blob/c180b0744bf74e9352be93a56c3905e59ea79cad/yarn.lock#L114

I ran the following command to install it:

```sh
yarn add semver@^7.3.5
```

The semver for `semver` matches the versions already used in `yarn.lock`.