### PR TITLE
fix: don't announce support for codeActionKinds

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -217,9 +217,7 @@ export class LspServer {
                     triggerCharacters: ['.', '"', '\'', '/', '@', '<'],
                     resolveProvider: true
                 },
-                codeActionProvider: {
-                    codeActionKinds: [CodeActions.SourceOrganizeImportsTsLs]
-                },
+                codeActionProvider: true,
                 definitionProvider: true,
                 documentFormattingProvider: true,
                 documentRangeFormattingProvider: true,


### PR DESCRIPTION
Announcing support for that code action enables it to be used on saving
with editors that support the Code-Action-On-Save functionality but
the way it works is problematic right now because tsserver returns
an edit even if imports are already correct. That results in running
this code action over and over until editor gives up due to a timeout.

This should be fixed either in tsserver or this server by not returning
a code action if nothing is supposed to change. It's not trivial to
fix though.