### PR TITLE
fix: mark import completions as snippets

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -48,7 +48,7 @@ export function asCompletionItem(entry: tsp.CompletionEntry, file: string, posit
         item.detail = asPlainText(sourceDisplay);
     }
 
-    if (item.kind === lsp.CompletionItemKind.Function || item.kind === lsp.CompletionItemKind.Method) {
+    if (entry.isImportStatementCompletion || item.kind === lsp.CompletionItemKind.Function || item.kind === lsp.CompletionItemKind.Method) {
         item.insertTextFormat = lsp.InsertTextFormat.Snippet;
     }
 


### PR DESCRIPTION
This was missing, resulting in import completions leaving stray `$1`
around.