### PR TITLE
feat: add support for snippet completions of method

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ Some of the preferences can be controlled through the `workspace/didChangeConfig
 [language].inlayHints.includeInlayParameterNameHintsWhenArgumentMatchesName: boolean;
 [language].inlayHints.includeInlayPropertyDeclarationTypeHints: boolean;
 [language].inlayHints.includeInlayVariableTypeHints: boolean;
+/**
+ * Complete functions with their parameter signature.
+ * @default false
+ */
+completions.completeFunctionCalls: boolean;
 // Diagnostics code to be omitted when reporting diagnostics.
 // See https://github.com/microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json for a full list of valid codes.
 diagnostics.ignoredCodes: number[];

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -502,7 +502,7 @@ export class LspServer {
         if (!details) {
             return item;
         }
-        return asResolvedCompletionItem(item, details);
+        return asResolvedCompletionItem(item, details, this.tspClient, this.workspaceConfiguration.completions || {});
     }
 
     async hover(params: lsp.TextDocumentPositionParams): Promise<lsp.Hover> {

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -16,6 +16,15 @@ export namespace TypeScriptRenameRequest {
     export const type = new lsp.RequestType<lsp.TextDocumentPositionParams, void, void>('_typescript.rename');
 }
 
+export class DisplayPartKind {
+    public static readonly functionName = 'functionName';
+    public static readonly methodName = 'methodName';
+    public static readonly parameterName = 'parameterName';
+    public static readonly propertyName = 'propertyName';
+    public static readonly punctuation = 'punctuation';
+    public static readonly text = 'text';
+}
+
 export interface TypeScriptPlugin {
     name: string;
     location: string;
@@ -51,5 +60,10 @@ interface TypeScriptWorkspaceSettingsDiagnostics {
 export interface TypeScriptWorkspaceSettings {
     javascript?: TypeScriptWorkspaceSettingsLanguageSettings;
     typescript?: TypeScriptWorkspaceSettingsLanguageSettings;
+    completions?: CompletionOptions;
     diagnostics?: TypeScriptWorkspaceSettingsDiagnostics;
+}
+
+export interface CompletionOptions {
+    completeFunctionCalls?: boolean;
 }

--- a/src/utils/SnippetString.ts
+++ b/src/utils/SnippetString.ts
@@ -1,0 +1,75 @@
+export default class SnippetString {
+    public static isSnippetString(thing: any): thing is SnippetString {
+        if (thing instanceof SnippetString) {
+            return true;
+        }
+        if (!thing) {
+            return false;
+        }
+        return typeof thing.value === 'string';
+    }
+
+    private static _escape(value: string): string {
+        return value.replace(/\$|}|\\/g, '\\$&');
+    }
+
+    private _tabstop = 1;
+
+    public value: string;
+
+    constructor(value?: string) {
+        this.value = value || '';
+    }
+
+    public appendText(str: string): SnippetString {
+        this.value += SnippetString._escape(str);
+        return this;
+    }
+
+    public appendTabstop(n: number = this._tabstop++): SnippetString {
+        this.value += '$';
+        this.value += n;
+        return this;
+    }
+
+    public appendPlaceholder(value: string | ((snippet: SnippetString) => any), n: number = this._tabstop++): SnippetString {
+        if (typeof value === 'function') {
+            const nested = new SnippetString();
+            nested._tabstop = this._tabstop;
+            value(nested);
+            this._tabstop = nested._tabstop;
+            value = nested.value;
+        } else {
+            value = SnippetString._escape(value);
+        }
+
+        this.value += '${';
+        this.value += n;
+        this.value += ':';
+        this.value += value;
+        this.value += '}';
+
+        return this;
+    }
+
+    public appendVariable(name: string, defaultValue?: string | ((snippet: SnippetString) => any)): SnippetString {
+        if (typeof defaultValue === 'function') {
+            const nested = new SnippetString();
+            nested._tabstop = this._tabstop;
+            defaultValue(nested);
+            this._tabstop = nested._tabstop;
+            defaultValue = nested.value;
+        } else if (typeof defaultValue === 'string') {
+            defaultValue = defaultValue.replace(/\$|}/g, '\\$&');
+        }
+
+        this.value += '${';
+        this.value += name;
+        if (defaultValue) {
+            this.value += ':';
+            this.value += defaultValue;
+        }
+        this.value += '}';
+        return this;
+    }
+}

--- a/src/utils/typeConverters.ts
+++ b/src/utils/typeConverters.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/**
+ * Helpers for converting FROM LanguageServer types language-server ts types
+ */
+import type * as lsp from 'vscode-languageserver-protocol';
+import type tsp from 'typescript/lib/protocol';
+
+export namespace Position {
+    export const fromLocation = (tslocation: tsp.Location): lsp.Position => {
+        return {
+            line: tslocation.line - 1,
+            character: tslocation.offset - 1
+        };
+    };
+
+    export const toLocation = (position: lsp.Position): tsp.Location => ({
+        line: position.line + 1,
+        offset: position.character + 1
+    });
+
+    export const toFileLocationRequestArgs = (file: string, position: lsp.Position): tsp.FileLocationRequestArgs => ({
+        file,
+        line: position.line + 1,
+        offset: position.character + 1
+    });
+}


### PR DESCRIPTION
On resolving a completion item, additional information are pulled and the `insertText` of the completion is updated with an extended snippet.

This unfortunately is not supported by the editor I'm using (ST) due to it being unable to resolve the completion before triggering the completion but it will hopefully work in other editors.

Fixes #198