### PR TITLE
feat: implement additional code actions for handling auto-fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ diagnostics.ignoredCodes: number[];
 Server announces support for the following code action kinds:
 
  - `source.addMissingImports.ts` - adds imports for used but not imported symbols
- - `source.fixAll.ts` - despite the name, fixing a couple of specific issues: unreachable code, await in non-async functions, incorrectly implemented interface
+ - `source.fixAll.ts` - despite the name, fixes a couple of specific issues: unreachable code, await in non-async functions, incorrectly implemented interface
  - `source.removeUnused.ts` - removes declared but unused variables
  - `source.organizeImports.ts` - organizes and removes unused imports
 

--- a/README.md
+++ b/README.md
@@ -175,13 +175,24 @@ diagnostics.ignoredCodes: number[];
 
 ## Code actions on save
 
-Server announces support for the `source.organizeImports.ts-ls` code action which allows editors that support running code actions on save to automatically organize imports on saving. The user can enable it with a setting similar to (can vary per-editor):
+Server announces support for the following code action kinds:
+
+ - `source.addMissingImports.ts` - adds imports for used but not imported symbols
+ - `source.fixAll.ts` - despite the name, fixing a couple of specific issues: unreachable code, await in non-async functions, incorrectly implemented interface
+ - `source.removeUnused.ts` - removes declared but unused variables
+ - `source.organizeImports.ts` - organizes and removes unused imports
+
+This allows editors that support running code actions on save to automatically run fixes associated with those kinds.
+
+Those code actions, if they apply in the current code, should also be presented in the list of "Source Actions" if the editor exposes those.
+
+The user can enable it with a setting similar to (can vary per-editor):
 
 ```js
 "codeActionsOnSave": {
+    "source.organizeImports.ts": true,
+    // or just
     "source.organizeImports": true,
-    // or
-    "source.organizeImports.ts-ls": true,
 }
 ```
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,5 +17,8 @@ export const Commands = {
 };
 
 export const CodeActions = {
-    SourceOrganizeImportsTsLs: 'source.organizeImports.ts-ls'
+    SourceAddMissingImportsTs: 'source.addMissingImports.ts',
+    SourceFixAllTs: 'source.fixAll.ts',
+    SourceRemoveUnusedTs: 'source.removeUnused.ts',
+    SourceOrganizeImportsTs: 'source.organizeImports.ts'
 };

--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -32,7 +32,7 @@ class FileDiagnostics {
         this.publishDiagnostics({ uri: this.uri, diagnostics });
     }, 50);
 
-    protected getDiagnostics(): lsp.Diagnostic[] {
+    public getDiagnostics(): lsp.Diagnostic[] {
         const result: lsp.Diagnostic[] = [];
         for (const diagnostics of this.diagnosticsPerKind.values()) {
             for (const diagnostic of diagnostics) {
@@ -74,6 +74,11 @@ export class DiagnosticEventQueue {
 
     updateIgnoredDiagnosticCodes(ignoredCodes: readonly number[]): void {
         this.ignoredDiagnosticCodes = new Set(ignoredCodes);
+    }
+
+    public getDiagnosticsForFile(file: string): lsp.Diagnostic[] {
+        const uri = pathToUri(file, this.documents);
+        return this.diagnostics.get(uri)?.getDiagnostics() || [];
     }
 
     private isDiagnosticIgnored(diagnostic: tsp.Diagnostic) : boolean {

--- a/src/features/fix-all.ts
+++ b/src/features/fix-all.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import tsp, { CommandTypes } from 'typescript/lib/protocol';
+import * as lsp from 'vscode-languageserver/node';
+import { CodeActions } from '../commands';
+import { LspDocuments } from '../document';
+import { toFileRangeRequestArgs, toTextDocumentEdit } from '../protocol-translation';
+import { TspClient } from '../tsp-client';
+import * as errorCodes from '../utils/errorCodes';
+import * as fixNames from '../utils/fixNames';
+
+interface AutoFix {
+    readonly codes: Set<number>;
+    readonly fixName: string;
+}
+
+async function buildIndividualFixes(
+    fixes: readonly AutoFix[],
+    client: TspClient,
+    file: string,
+    documents: LspDocuments,
+    diagnostics: readonly lsp.Diagnostic[]
+): Promise<lsp.TextDocumentEdit[]> {
+    const edits: lsp.TextDocumentEdit[] = [];
+    for (const diagnostic of diagnostics) {
+        for (const { codes, fixName } of fixes) {
+            if (!codes.has(diagnostic.code as number)) {
+                continue;
+            }
+
+            const args: tsp.CodeFixRequestArgs = {
+                ...toFileRangeRequestArgs(file, diagnostic.range),
+                errorCodes: [+diagnostic.code!]
+            };
+
+            const response = await client.request(CommandTypes.GetCodeFixes, args);
+            if (response.type !== 'response') {
+                continue;
+            }
+
+            const fix = response.body?.find(fix => fix.fixName === fixName);
+            if (fix) {
+                edits.push(...fix.changes.map(change => toTextDocumentEdit(change, documents)));
+                break;
+            }
+        }
+    }
+    return edits;
+}
+
+async function buildCombinedFix(
+    fixes: readonly AutoFix[],
+    client: TspClient,
+    file: string,
+    documents: LspDocuments,
+    diagnostics: readonly lsp.Diagnostic[]
+): Promise<lsp.TextDocumentEdit[]> {
+    const edits: lsp.TextDocumentEdit[] = [];
+    for (const diagnostic of diagnostics) {
+        for (const { codes, fixName } of fixes) {
+            if (!codes.has(diagnostic.code as number)) {
+                continue;
+            }
+
+            const args: tsp.CodeFixRequestArgs = {
+                ...toFileRangeRequestArgs(file, diagnostic.range),
+                errorCodes: [+diagnostic.code!]
+            };
+
+            const response = await client.request(CommandTypes.GetCodeFixes, args);
+            if (response.type !== 'response' || !response.body?.length) {
+                continue;
+            }
+
+            const fix = response.body?.find(fix => fix.fixName === fixName);
+            if (!fix) {
+                continue;
+            }
+
+            if (!fix.fixId) {
+                edits.push(...fix.changes.map(change => toTextDocumentEdit(change, documents)));
+                return edits;
+            }
+
+            const combinedArgs: tsp.GetCombinedCodeFixRequestArgs = {
+                scope: {
+                    type: 'file',
+                    args: { file }
+                },
+                fixId: fix.fixId
+            };
+
+            const combinedResponse = await client.request(CommandTypes.GetCombinedCodeFix, combinedArgs);
+            if (combinedResponse.type !== 'response' || !combinedResponse.body) {
+                return edits;
+            }
+
+            edits.push(...combinedResponse.body.changes.map(change => toTextDocumentEdit(change, documents)));
+            return edits;
+        }
+    }
+    return edits;
+}
+
+// #region Source Actions
+
+abstract class SourceAction {
+    abstract build(
+        client: TspClient,
+        file: string,
+        documents: LspDocuments,
+        diagnostics: readonly lsp.Diagnostic[]
+    ): Promise<lsp.CodeAction | null>;
+}
+
+class SourceFixAll extends SourceAction {
+    private readonly title = 'Fix all';
+    static readonly kind = CodeActions.SourceFixAllTs;
+
+    async build(
+        client: TspClient,
+        file: string,
+        documents: LspDocuments,
+        diagnostics: readonly lsp.Diagnostic[]
+    ): Promise<lsp.CodeAction | null> {
+        const edits: lsp.TextDocumentEdit[] = [];
+        edits.push(...await buildIndividualFixes([
+            { codes: errorCodes.incorrectlyImplementsInterface, fixName: fixNames.classIncorrectlyImplementsInterface },
+            { codes: errorCodes.asyncOnlyAllowedInAsyncFunctions, fixName: fixNames.awaitInSyncFunction }
+        ], client, file, documents, diagnostics));
+        edits.push(...await buildCombinedFix([
+            { codes: errorCodes.unreachableCode, fixName: fixNames.unreachableCode }
+        ], client, file, documents, diagnostics));
+        if (!edits.length) {
+            return null;
+        }
+        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceFixAll.kind);
+    }
+}
+
+class SourceRemoveUnused extends SourceAction {
+    private readonly title = 'Remove all unused code';
+    static readonly kind = CodeActions.SourceRemoveUnusedTs;
+
+    async build(
+        client: TspClient,
+        file: string,
+        documents: LspDocuments,
+        diagnostics: readonly lsp.Diagnostic[]
+    ): Promise<lsp.CodeAction | null> {
+        const edits = await buildCombinedFix([
+            { codes: errorCodes.variableDeclaredButNeverUsed, fixName: fixNames.unusedIdentifier }
+        ], client, file, documents, diagnostics);
+        if (!edits.length) {
+            return null;
+        }
+        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceRemoveUnused.kind);
+    }
+}
+
+class SourceAddMissingImports extends SourceAction {
+    private readonly title = 'Add all missing imports';
+    static readonly kind = CodeActions.SourceAddMissingImportsTs;
+
+    async build(
+        client: TspClient,
+        file: string,
+        documents: LspDocuments,
+        diagnostics: readonly lsp.Diagnostic[]
+    ): Promise<lsp.CodeAction | null> {
+        const edits = await buildCombinedFix([
+            { codes: errorCodes.cannotFindName, fixName: fixNames.fixImport }
+        ], client, file, documents, diagnostics);
+        if (!edits.length) {
+            return null;
+        }
+        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceAddMissingImports.kind);
+    }
+}
+
+//#endregion
+
+export class TypeScriptAutoFixProvider {
+    private static kindProviders = [
+        SourceFixAll,
+        SourceRemoveUnused,
+        SourceAddMissingImports
+    ];
+    private providers: SourceAction[];
+
+    constructor(private readonly client: TspClient) {
+        this.providers = TypeScriptAutoFixProvider.kindProviders.map(provider => new provider());
+    }
+
+    public static get kinds(): lsp.CodeActionKind[] {
+        return TypeScriptAutoFixProvider.kindProviders.map(provider => provider.kind);
+    }
+
+    public async provideCodeActions(file: string, diagnostics: lsp.Diagnostic[], documents: LspDocuments): Promise<lsp.CodeAction[]> {
+        const results = await Promise.all(this.providers.map(action => action.build(this.client, file, documents, diagnostics)));
+        return results.flatMap(result => result || []);
+    }
+}

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -1066,8 +1066,8 @@ existsSync('t');`
         const result = (await server.codeAction({
             textDocument: doc,
             range: {
-                start: { line: 1, character: 29 },
-                end: { line: 1, character: 53 }
+                start: { line: 0, character: 0 },
+                end: { line: 3, character: 0 }
             },
             context: {
                 diagnostics: [{

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -991,7 +991,7 @@ describe('code actions', () => {
         ]);
     }).timeout(10000);
 
-    it.only('provides "fix all" when explicitly requested in only', async () => {
+    it('provides "fix all" when explicitly requested in only', async () => {
         const doc = {
             uri: uri('bar.ts'),
             languageId: 'typescript',

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -927,7 +927,7 @@ describe('code actions', () => {
                     code: 6133,
                     message: 'unused arg'
                 }],
-                only: [CodeActions.SourceOrganizeImportsTsLs]
+                only: [CodeActions.SourceOrganizeImportsTs]
             }
         }))!;
 
@@ -961,13 +961,13 @@ existsSync('t');`
                     code: 6133,
                     message: 'unused arg'
                 }],
-                only: [CodeActions.SourceOrganizeImportsTsLs]
+                only: [CodeActions.SourceOrganizeImportsTs]
             }
         }))!;
 
         assert.deepEqual(result, [
             {
-                kind: CodeActions.SourceOrganizeImportsTsLs,
+                kind: CodeActions.SourceOrganizeImportsTs,
                 title: 'Organize imports',
                 edit: {
                     documentChanges: [

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -934,7 +934,124 @@ describe('code actions', () => {
         assert.deepEqual(result, []);
     }).timeout(10000);
 
-    it('can provide organize imports when explicitly requested in only', async () => {
+    it('provides "add missing imports" when explicitly requested in only', async () => {
+        const doc = {
+            uri: uri('bar.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: 'existsSync(\'t\');'
+        };
+        server.didOpenTextDocument({
+            textDocument: doc
+        });
+        await server.requestDiagnostics();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        const result = (await server.codeAction({
+            textDocument: doc,
+            range: {
+                start: { line: 1, character: 29 },
+                end: { line: 1, character: 53 }
+            },
+            context: {
+                diagnostics: [],
+                only: [CodeActions.SourceAddMissingImportsTs]
+            }
+        }))!;
+
+        assert.deepEqual(result, [
+            {
+                kind: CodeActions.SourceAddMissingImportsTs,
+                title: 'Add all missing imports',
+                edit: {
+                    documentChanges: [
+                        {
+                            edits: [
+                                {
+                                    newText: 'import { existsSync } from "fs";\n\n',
+                                    range: {
+                                        end: {
+                                            character: 0,
+                                            line: 0
+                                        },
+                                        start: {
+                                            character: 0,
+                                            line: 0
+                                        }
+                                    }
+                                }
+                            ],
+                            textDocument: {
+                                uri: uri('bar.ts'),
+                                version: 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]);
+    }).timeout(10000);
+
+    it.only('provides "fix all" when explicitly requested in only', async () => {
+        const doc = {
+            uri: uri('bar.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: `function foo() {
+  return
+  setTimeout(() => {})
+}`
+        };
+        server.didOpenTextDocument({
+            textDocument: doc
+        });
+        await server.requestDiagnostics();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        const result = (await server.codeAction({
+            textDocument: doc,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 4, character: 0 }
+            },
+            context: {
+                diagnostics: [],
+                only: [CodeActions.SourceFixAllTs]
+            }
+        }))!;
+
+        assert.deepEqual(result, [
+            {
+                kind: CodeActions.SourceFixAllTs,
+                title: 'Fix all',
+                edit: {
+                    documentChanges: [
+                        {
+                            edits: [
+                                {
+                                    newText: '',
+                                    range: {
+                                        end: {
+                                            character: 0,
+                                            line: 3
+                                        },
+                                        start: {
+                                            character: 0,
+                                            line: 2
+                                        }
+                                    }
+                                }
+                            ],
+                            textDocument: {
+                                uri: uri('bar.ts'),
+                                version: 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]);
+    }).timeout(10000);
+
+    it('provides organize imports when explicitly requested in only', async () => {
         const doc = {
             uri: uri('bar.ts'),
             languageId: 'typescript',
@@ -996,6 +1113,63 @@ existsSync('t');`
                                         start: {
                                             character: 0,
                                             line: 1
+                                        }
+                                    }
+                                }
+                            ],
+                            textDocument: {
+                                uri: uri('bar.ts'),
+                                version: 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]);
+    }).timeout(10000);
+
+    it('provides "remove unused" when explicitly requested in only', async () => {
+        const doc = {
+            uri: uri('bar.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: 'import { existsSync } from \'fs\';'
+        };
+        server.didOpenTextDocument({
+            textDocument: doc
+        });
+        await server.requestDiagnostics();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        const result = (await server.codeAction({
+            textDocument: doc,
+            range: {
+                start: position(doc, 'existsSync'),
+                end: positionAfter(doc, 'existsSync')
+            },
+            context: {
+                diagnostics: [],
+                only: [CodeActions.SourceRemoveUnusedTs]
+            }
+        }))!;
+
+        assert.deepEqual(result, [
+            {
+                kind: CodeActions.SourceRemoveUnusedTs,
+                title: 'Remove all unused code',
+                edit: {
+                    documentChanges: [
+                        {
+                            edits: [
+                                {
+                                    newText: '',
+                                    range: {
+                                        end: {
+                                            character: 32,
+                                            line: 0
+                                        },
+                                        start: {
+                                            character: 0,
+                                            line: 0
                                         }
                                     }
                                 }

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -804,7 +804,7 @@ export class LspServer {
         // sure that diagnostics are up-to-date. Thus we check `pendingDebouncedRequest` to see if there are *any*
         // pending diagnostic requests (regardless of for which file).
         // In general would be better to replace the whole diagnostics handling logic with the one from
-        // bufferSyncSupport.ts' in VSCode's typescript language features.
+        // bufferSyncSupport.ts in VSCode's typescript language features.
         if (!this.pendingDebouncedRequest && only?.some(kind => kind === CodeActionKind.Source || kind.startsWith(CodeActionKind.Source + '.'))) {
             const diagnostics = this.diagnosticQueue?.getDiagnosticsForFile(file) || [];
             if (diagnostics.length) {

--- a/src/organize-imports.spec.ts
+++ b/src/organize-imports.spec.ts
@@ -18,7 +18,7 @@ describe('provideOrganizeImports', () => {
         const actual = provideOrganizeImports(response as any as tsp.OrganizeImportsResponse, undefined);
         const expected = [{
             title: 'Organize imports',
-            kind: CodeActions.SourceOrganizeImportsTsLs,
+            kind: CodeActions.SourceOrganizeImportsTs,
             edit: {
                 documentChanges: [
                     {

--- a/src/organize-imports.ts
+++ b/src/organize-imports.ts
@@ -20,6 +20,6 @@ export function provideOrganizeImports(response: tsp.OrganizeImportsResponse | u
         lsp.CodeAction.create(
             'Organize imports',
             { documentChanges: response.body.map(edit => toTextDocumentEdit(edit, documents)) },
-            CodeActions.SourceOrganizeImportsTsLs
+            CodeActions.SourceOrganizeImportsTs
         )];
 }

--- a/src/tsp-client.ts
+++ b/src/tsp-client.ts
@@ -45,7 +45,7 @@ interface TypeScriptRequestTypes {
     'format': [protocol.FormatRequestArgs, protocol.FormatResponse];
     'formatonkey': [protocol.FormatOnKeyRequestArgs, protocol.FormatResponse];
     'getApplicableRefactors': [protocol.GetApplicableRefactorsRequestArgs, protocol.GetApplicableRefactorsResponse];
-    'getCodeFixes': [protocol.CodeFixRequestArgs, protocol.GetCodeFixesResponse];
+    'getCodeFixes': [protocol.CodeFixRequestArgs, protocol.CodeFixResponse];
     'getCombinedCodeFix': [protocol.GetCombinedCodeFixRequestArgs, protocol.GetCombinedCodeFixResponse];
     'getEditsForFileRename': [protocol.GetEditsForFileRenameRequestArgs, protocol.GetEditsForFileRenameResponse];
     'getEditsForRefactor': [protocol.GetEditsForRefactorRequestArgs, protocol.GetEditsForRefactorResponse];

--- a/src/utils/errorCodes.ts
+++ b/src/utils/errorCodes.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const variableDeclaredButNeverUsed = new Set([6196, 6133]);
+export const propertyDeclaretedButNeverUsed = new Set([6138]);
+export const allImportsAreUnused = new Set([6192]);
+export const unreachableCode = new Set([7027]);
+export const unusedLabel = new Set([7028]);
+export const fallThroughCaseInSwitch = new Set([7029]);
+export const notAllCodePathsReturnAValue = new Set([7030]);
+export const incorrectlyImplementsInterface = new Set([2420]);
+export const cannotFindName = new Set([2552, 2304]);
+export const extendsShouldBeImplements = new Set([2689]);
+export const asyncOnlyAllowedInAsyncFunctions = new Set([1308]);

--- a/src/utils/fixNames.ts
+++ b/src/utils/fixNames.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const annotateWithTypeFromJSDoc = 'annotateWithTypeFromJSDoc';
+export const constructorForDerivedNeedSuperCall = 'constructorForDerivedNeedSuperCall';
+export const extendsInterfaceBecomesImplements = 'extendsInterfaceBecomesImplements';
+export const awaitInSyncFunction = 'fixAwaitInSyncFunction';
+export const classIncorrectlyImplementsInterface = 'fixClassIncorrectlyImplementsInterface';
+export const classDoesntImplementInheritedAbstractMember = 'fixClassDoesntImplementInheritedAbstractMember';
+export const unreachableCode = 'fixUnreachableCode';
+export const unusedIdentifier = 'unusedIdentifier';
+export const forgottenThisPropertyAccess = 'forgottenThisPropertyAccess';
+export const spelling = 'spelling';
+export const fixImport = 'import';
+export const addMissingAwait = 'addMissingAwait';
+export const addMissingOverride = 'fixOverrideModifier';


### PR DESCRIPTION
Implements additional code actions that can be triggered using the Code-Actions-On-Save functionality of the editor or through "Source actions" menu.

 - `source.addMissingImports.ts` - adds imports for used but not imported symbols
 - `source.fixAll.ts` - despite the name, fixes a couple of specific issues: unreachable code, await in non-async functions, incorrectly implemented interface
 - `source.removeUnused.ts` - removes declared but unused variables
 - `source.organizeImports.ts` (was already supported but renamed the suffix from `ts-ls` to `ts`) - organizes and removes unused imports

Those are not exposed in the normal code action menu that is shown for individual diagnostics. This matches the behavior of VSCode but not sure about COC.

Fixes #235