### PR TITLE
feat: report progress when loading the project

### DIFF
--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -6,9 +6,18 @@
  */
 
 import * as lsp from 'vscode-languageserver/node';
+import { WorkDoneProgressServerReporter } from 'vscode-languageserver/node';
 import { TypeScriptRenameRequest } from './ts-protocol';
 
+export interface ProgressReporter {
+    begin(message?: string): void;
+    report(message: string): void;
+    end(): void;
+}
+
 export interface LspClient {
+    setClientCapabilites(capabilites: lsp.ClientCapabilities): void;
+    createProgressReporter(): ProgressReporter;
     publishDiagnostics(args: lsp.PublishDiagnosticsParams): void;
     showMessage(args: lsp.ShowMessageParams): void;
     logMessage(args: lsp.LogMessageParams): void;
@@ -18,7 +27,47 @@ export interface LspClient {
 }
 
 export class LspClientImpl implements LspClient {
-    constructor(protected connection: lsp.Connection) {
+    private clientCapabilities?: lsp.ClientCapabilities;
+
+    constructor(protected connection: lsp.Connection) {}
+
+    setClientCapabilites(capabilites: lsp.ClientCapabilities): void {
+        this.clientCapabilities = capabilites;
+    }
+
+    createProgressReporter(): ProgressReporter {
+        let workDoneProgress: Promise<WorkDoneProgressServerReporter> | undefined;
+        return {
+            begin: (message = '') => {
+                if (this.clientCapabilities?.window?.workDoneProgress) {
+                    workDoneProgress = this.connection.window.createWorkDoneProgress();
+                    workDoneProgress
+                        .then((progress) => {
+                            progress.begin(message);
+                        })
+                        .catch(() => {});
+                }
+            },
+            report: (message: string) => {
+                if (workDoneProgress) {
+                    workDoneProgress
+                        .then((progress) => {
+                            progress.report(message);
+                        })
+                        .catch(() => {});
+                }
+            },
+            end: () => {
+                if (workDoneProgress) {
+                    workDoneProgress
+                        .then((progress) => {
+                            progress.done();
+                        })
+                        .catch(() => {});
+                    workDoneProgress = undefined;
+                }
+            }
+        };
     }
 
     publishDiagnostics(args: lsp.PublishDiagnosticsParams): void {

--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -6,7 +6,6 @@
  */
 
 import * as lsp from 'vscode-languageserver/node';
-import { WorkDoneProgressServerReporter } from 'vscode-languageserver/node';
 import { TypeScriptRenameRequest } from './ts-protocol';
 
 export interface ProgressReporter {
@@ -36,7 +35,7 @@ export class LspClientImpl implements LspClient {
     }
 
     createProgressReporter(): ProgressReporter {
-        let workDoneProgress: Promise<WorkDoneProgressServerReporter> | undefined;
+        let workDoneProgress: Promise<lsp.WorkDoneProgressServerReporter> | undefined;
         return {
             begin: (message = '') => {
                 if (this.clientCapabilities?.window?.workDoneProgress) {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -41,7 +41,7 @@ import { TypeScriptAutoFixProvider } from './features/fix-all';
 import { LspClient, ProgressReporter } from './lsp-client';
 
 class ServerInitializingIndicator {
-    private _loadingProjectName?: string | undefined;
+    private _loadingProjectName?: string;
     private _progressReporter?: ProgressReporter;
 
     constructor(private lspClient: LspClient) {}

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -41,15 +41,14 @@ import { TypeScriptAutoFixProvider } from './features/fix-all';
 import { LspClient, ProgressReporter } from './lsp-client';
 
 class ServerInitializingIndicator {
-    private _loadingProject?: { project: string | undefined; resolve: () => void; reject: () => void; };
+    private _loadingProjectName?: string | undefined;
     private _progressReporter?: ProgressReporter;
 
     constructor(private lspClient: LspClient) {}
 
     public reset(): void {
-        if (this._loadingProject) {
-            this._loadingProject.reject();
-            this._loadingProject = undefined;
+        if (this._loadingProjectName) {
+            this._loadingProjectName = undefined;
             if (this._progressReporter) {
                 this._progressReporter.end();
                 this._progressReporter = undefined;
@@ -65,18 +64,14 @@ class ServerInitializingIndicator {
         // the incoming project loading task is.
         this.reset();
 
+        this._loadingProjectName = projectName;
         this._progressReporter = this.lspClient.createProgressReporter();
         this._progressReporter.begin('Initializing JS/TS language features');
-
-        new Promise<void>((resolve, reject) => {
-            this._loadingProject = { project: projectName, resolve, reject };
-        });
     }
 
     public finishedLoadingProject(projectName: string | undefined): void {
-        if (this._loadingProject && this._loadingProject.project === projectName) {
-            this._loadingProject.resolve();
-            this._loadingProject = undefined;
+        if (this._loadingProjectName && this._loadingProjectName === projectName) {
+            this._loadingProjectName = undefined;
             if (this._progressReporter) {
                 this._progressReporter.end();
                 this._progressReporter = undefined;

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -56,9 +56,6 @@ class ServerInitializingIndicator {
         }
     }
 
-    /**
-     * Signal that a project has started loading.
-     */
     public startedLoadingProject(projectName: string): void {
         // TS projects are loaded sequentially. Cancel existing task because it should always be resolved before
         // the incoming project loading task is.

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -59,7 +59,7 @@ class ServerInitializingIndicator {
     /**
      * Signal that a project has started loading.
      */
-    public startedLoadingProject(projectName: string | undefined): void {
+    public startedLoadingProject(projectName: string): void {
         // TS projects are loaded sequentially. Cancel existing task because it should always be resolved before
         // the incoming project loading task is.
         this.reset();
@@ -69,8 +69,8 @@ class ServerInitializingIndicator {
         this._progressReporter.begin('Initializing JS/TS language features');
     }
 
-    public finishedLoadingProject(projectName: string | undefined): void {
-        if (this._loadingProjectName && this._loadingProjectName === projectName) {
+    public finishedLoadingProject(projectName: string): void {
+        if (this._loadingProjectName === projectName) {
             this._loadingProjectName = undefined;
             if (this._progressReporter) {
                 this._progressReporter.end();

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -82,6 +82,14 @@ export async function createServer(options: {
         tsserverLogVerbosity: options.tsserverLogVerbosity,
         tsserverLogFile: path.resolve(__dirname, '../tsserver.log'),
         lspClient: {
+            setClientCapabilites() {},
+            createProgressReporter() {
+                return {
+                    begin() {},
+                    report() {},
+                    end() {}
+                };
+            },
             publishDiagnostics: options.publishDiagnostics,
             showMessage(args: lsp.ShowMessageParams): void {
                 throw args; // should not be called.

--- a/src/tsp-command-types.ts
+++ b/src/tsp-command-types.ts
@@ -96,7 +96,9 @@ export const enum EventTypes {
     SyntaxDiag = 'syntaxDiag',
     SementicDiag = 'semanticDiag',
     SuggestionDiag = 'suggestionDiag',
-    Telemetry = 'telemetry'
+    Telemetry = 'telemetry',
+    ProjectLoadingStart = 'projectLoadingStart',
+    ProjectLoadingFinish = 'projectLoadingFinish',
 }
 
 export enum ScriptElementKind {


### PR DESCRIPTION
Added server-initiated progress that notifies the client when the typescript project is being loaded. This should trigger on initial loading and also on changing project settings in `tsconfig.json`. Basically any time Typescript decides to (re)load the project since it's based on typescript notifications.

Fixes #237