### PR TITLE
fix: correct matching of "only" kinds provided by the client

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,10 +15,3 @@ export const Commands = {
     /** Commands below should be implemented by the client */
     SELECT_REFACTORING: '_typescript.selectRefactoring'
 };
-
-export const CodeActions = {
-    SourceAddMissingImportsTs: 'source.addMissingImports.ts',
-    SourceFixAllTs: 'source.fixAll.ts',
-    SourceRemoveUnusedTs: 'source.removeUnused.ts',
-    SourceOrganizeImportsTs: 'source.organizeImports.ts'
-};

--- a/src/features/fix-all.ts
+++ b/src/features/fix-all.ts
@@ -5,12 +5,12 @@
 
 import tsp, { CommandTypes } from 'typescript/lib/protocol';
 import * as lsp from 'vscode-languageserver/node';
-import { CodeActions } from '../commands';
 import { LspDocuments } from '../document';
 import { toFileRangeRequestArgs, toTextDocumentEdit } from '../protocol-translation';
 import { TspClient } from '../tsp-client';
 import * as errorCodes from '../utils/errorCodes';
 import * as fixNames from '../utils/fixNames';
+import { CodeActionKind } from '../utils/types';
 
 interface AutoFix {
     readonly codes: Set<number>;
@@ -118,7 +118,7 @@ abstract class SourceAction {
 
 class SourceFixAll extends SourceAction {
     private readonly title = 'Fix all';
-    static readonly kind = CodeActions.SourceFixAllTs;
+    static readonly kind = CodeActionKind.SourceFixAllTs;
 
     async build(
         client: TspClient,
@@ -137,13 +137,13 @@ class SourceFixAll extends SourceAction {
         if (!edits.length) {
             return null;
         }
-        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceFixAll.kind);
+        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceFixAll.kind.value);
     }
 }
 
 class SourceRemoveUnused extends SourceAction {
     private readonly title = 'Remove all unused code';
-    static readonly kind = CodeActions.SourceRemoveUnusedTs;
+    static readonly kind = CodeActionKind.SourceRemoveUnusedTs;
 
     async build(
         client: TspClient,
@@ -157,13 +157,13 @@ class SourceRemoveUnused extends SourceAction {
         if (!edits.length) {
             return null;
         }
-        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceRemoveUnused.kind);
+        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceRemoveUnused.kind.value);
     }
 }
 
 class SourceAddMissingImports extends SourceAction {
     private readonly title = 'Add all missing imports';
-    static readonly kind = CodeActions.SourceAddMissingImportsTs;
+    static readonly kind = CodeActionKind.SourceAddMissingImportsTs;
 
     async build(
         client: TspClient,
@@ -177,7 +177,7 @@ class SourceAddMissingImports extends SourceAction {
         if (!edits.length) {
             return null;
         }
-        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceAddMissingImports.kind);
+        return lsp.CodeAction.create(this.title, { documentChanges: edits }, SourceAddMissingImports.kind.value);
     }
 }
 
@@ -195,7 +195,7 @@ export class TypeScriptAutoFixProvider {
         this.providers = TypeScriptAutoFixProvider.kindProviders.map(provider => new provider());
     }
 
-    public static get kinds(): lsp.CodeActionKind[] {
+    public static get kinds(): CodeActionKind[] {
         return TypeScriptAutoFixProvider.kindProviders.map(provider => provider.kind);
     }
 

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -11,8 +11,8 @@ import * as lspcalls from './lsp-protocol.calls.proposed';
 import { LspServer } from './lsp-server';
 import { uri, createServer, position, lastPosition, filePath, getDefaultClientCapabilities, positionAfter } from './test-utils';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { CodeActions } from './commands';
 import { TypeScriptWorkspaceSettings } from './ts-protocol';
+import { CodeActionKind } from './utils/types';
 
 const assert = chai.assert;
 
@@ -912,6 +912,8 @@ describe('code actions', () => {
         server.didOpenTextDocument({
             textDocument: doc
         });
+        await server.requestDiagnostics();
+        await new Promise(resolve => setTimeout(resolve, 200));
         const result = (await server.codeAction({
             textDocument: doc,
             range: {
@@ -927,7 +929,7 @@ describe('code actions', () => {
                     code: 6133,
                     message: 'unused arg'
                 }],
-                only: [CodeActions.SourceOrganizeImportsTs]
+                only: [CodeActionKind.SourceOrganizeImportsTs.value]
             }
         }))!;
 
@@ -954,13 +956,13 @@ describe('code actions', () => {
             },
             context: {
                 diagnostics: [],
-                only: [CodeActions.SourceAddMissingImportsTs]
+                only: [CodeActionKind.SourceAddMissingImportsTs.value]
             }
         }))!;
 
         assert.deepEqual(result, [
             {
-                kind: CodeActions.SourceAddMissingImportsTs,
+                kind: CodeActionKind.SourceAddMissingImportsTs.value,
                 title: 'Add all missing imports',
                 edit: {
                     documentChanges: [
@@ -1015,13 +1017,13 @@ describe('code actions', () => {
             },
             context: {
                 diagnostics: [],
-                only: [CodeActions.SourceFixAllTs]
+                only: [CodeActionKind.SourceFixAllTs.value]
             }
         }))!;
 
         assert.deepEqual(result, [
             {
-                kind: CodeActions.SourceFixAllTs,
+                kind: CodeActionKind.SourceFixAllTs.value,
                 title: 'Fix all',
                 edit: {
                     documentChanges: [
@@ -1079,13 +1081,13 @@ existsSync('t');`
                     code: 6133,
                     message: 'unused arg'
                 }],
-                only: [CodeActions.SourceOrganizeImportsTs]
+                only: [CodeActionKind.SourceOrganizeImportsTs.value]
             }
         }))!;
 
         assert.deepEqual(result, [
             {
-                kind: CodeActions.SourceOrganizeImportsTs,
+                kind: CodeActionKind.SourceOrganizeImportsTs.value,
                 title: 'Organize imports',
                 edit: {
                     documentChanges: [
@@ -1149,13 +1151,13 @@ existsSync('t');`
             },
             context: {
                 diagnostics: [],
-                only: [CodeActions.SourceRemoveUnusedTs]
+                only: [CodeActionKind.SourceRemoveUnusedTs.value]
             }
         }))!;
 
         assert.deepEqual(result, [
             {
-                kind: CodeActions.SourceRemoveUnusedTs,
+                kind: CodeActionKind.SourceRemoveUnusedTs.value,
                 title: 'Remove all unused code',
                 edit: {
                     documentChanges: [

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -851,10 +851,10 @@ export class LspServer {
         // pending diagnostic requests (regardless of for which file).
         // In general would be better to replace the whole diagnostics handling logic with the one from
         // bufferSyncSupport.ts in VSCode's typescript language features.
-        if (!this.pendingDebouncedRequest && kinds?.some(kind => TypeScriptAutoFixProvider.kinds.some(k => k.contains(kind)))) {
+        if (kinds && !this.pendingDebouncedRequest) {
             const diagnostics = this.diagnosticQueue?.getDiagnosticsForFile(file) || [];
             if (diagnostics.length) {
-                actions.push(...await this.typeScriptAutoFixProvider.provideCodeActions(file, diagnostics, this.documents));
+                actions.push(...await this.typeScriptAutoFixProvider.provideCodeActions(kinds, file, diagnostics, this.documents));
             }
         }
 

--- a/src/organize-imports.spec.ts
+++ b/src/organize-imports.spec.ts
@@ -2,7 +2,7 @@ import tsp from 'typescript/lib/protocol';
 import * as chai from 'chai';
 import { provideOrganizeImports } from './organize-imports';
 import { filePath, uri } from './test-utils';
-import { CodeActions } from './commands';
+import { CodeActionKind } from './utils/types';
 
 describe('provideOrganizeImports', () => {
     it('converts tsserver response to lsp code actions', () => {
@@ -18,7 +18,7 @@ describe('provideOrganizeImports', () => {
         const actual = provideOrganizeImports(response as any as tsp.OrganizeImportsResponse, undefined);
         const expected = [{
             title: 'Organize imports',
-            kind: CodeActions.SourceOrganizeImportsTs,
+            kind: CodeActionKind.SourceOrganizeImportsTs.value,
             edit: {
                 documentChanges: [
                     {

--- a/src/organize-imports.ts
+++ b/src/organize-imports.ts
@@ -9,7 +9,7 @@ import * as lsp from 'vscode-languageserver/node';
 import tsp from 'typescript/lib/protocol';
 import { toTextDocumentEdit } from './protocol-translation';
 import { LspDocuments } from './document';
-import { CodeActions } from './commands';
+import { CodeActionKind } from './utils/types';
 
 export function provideOrganizeImports(response: tsp.OrganizeImportsResponse | undefined, documents: LspDocuments | undefined): Array<lsp.CodeAction> {
     if (!response || response.body.length === 0) {
@@ -20,6 +20,6 @@ export function provideOrganizeImports(response: tsp.OrganizeImportsResponse | u
         lsp.CodeAction.create(
             'Organize imports',
             { documentChanges: response.body.map(edit => toTextDocumentEdit(edit, documents)) },
-            CodeActions.SourceOrganizeImportsTs
+            CodeActionKind.SourceOrganizeImportsTs.value
         )];
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -27,14 +27,35 @@ export class CodeActionKind {
         return this.value === other.value;
     }
 
+    /**
+     * Checks if `other` is a sub-kind of this `CodeActionKind`.
+     *
+     * The kind `"refactor.extract"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`,
+     * but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"` or `refactor`.
+     *
+     * @param other Kind to check.
+     */
     public contains(other: CodeActionKind): boolean {
         return this.equals(other) || this.value === '' || other.value.startsWith(this.value + CodeActionKind.sep);
     }
 
+    /**
+     * Checks if this code action kind intersects `other`.
+     *
+     * The kind `"refactor.extract"` for example intersects `refactor`, `"refactor.extract"` and ``"refactor.extract.function"`,
+     * but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"`.
+     *
+     * @param other Kind to check.
+     */
     public intersects(other: CodeActionKind): boolean {
         return this.contains(other) || other.contains(this);
     }
 
+    /**
+     * Create a new kind by appending a more specific selector to the current kind.
+     *
+     * Does not modify the current kind.
+     */
     public append(part: string): CodeActionKind {
         return new CodeActionKind(this.value + CodeActionKind.sep + part);
     }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as lsp from 'vscode-languageserver/node';
+
+export class CodeActionKind {
+    private static readonly sep = '.';
+
+    public static readonly Empty = new CodeActionKind(lsp.CodeActionKind.Empty);
+    public static readonly QuickFix = new CodeActionKind(lsp.CodeActionKind.QuickFix);
+    public static readonly Refactor = new CodeActionKind(lsp.CodeActionKind.Refactor);
+    public static readonly Source = new CodeActionKind(lsp.CodeActionKind.Source);
+    public static readonly SourceAddMissingImportsTs = CodeActionKind.Source.append('SourceAddMissingImportsTs').append('ts');
+    public static readonly SourceRemoveUnusedTs = CodeActionKind.Source.append('removeUnused').append('ts');
+    public static readonly SourceOrganizeImports = new CodeActionKind(lsp.CodeActionKind.SourceOrganizeImports);
+    public static readonly SourceOrganizeImportsTs = CodeActionKind.SourceOrganizeImports.append('ts');
+    public static readonly SourceFixAll = new CodeActionKind(lsp.CodeActionKind.SourceFixAll);
+    public static readonly SourceFixAllTs = CodeActionKind.SourceFixAll.append('ts');
+
+    constructor(
+        public readonly value: string
+    ) { }
+
+    public equals(other: CodeActionKind): boolean {
+        return this.value === other.value;
+    }
+
+    public contains(other: CodeActionKind): boolean {
+        return this.equals(other) || this.value === '' || other.value.startsWith(this.value + CodeActionKind.sep);
+    }
+
+    public intersects(other: CodeActionKind): boolean {
+        return this.contains(other) || other.contains(this);
+    }
+
+    public append(part: string): CodeActionKind {
+        return new CodeActionKind(this.value + CodeActionKind.sep + part);
+    }
+}


### PR DESCRIPTION
The matching of "only" code action kind provided by the client was not correct (especially for the "fixall" actions). Imported the `CodeActionKind` class from VSCode and using its matching logic to fix that.