### PR TITLE
chore(test): run tests through ts-node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: build
         run: yarn build
       - name: Unittest
-        run: yarn test
-      - name: Linti
+        run: yarn test:compiled
+      - name: Lint
         if: ${{ matrix.node-version == '16.x' }}
         run: yarn lint

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "clean": "rimraf lib *.tsbuildinfo",
-    "test": "mocha --exit --reporter spec \"./lib/**/*.spec.js\"",
+    "test": "TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register",
+    "test:watch": "TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register --watch",
     "lint": "eslint --ext \".js,.ts\" src",
     "build": "concurrently -n compile,lint -c blue,green \"yarn compile\" \"yarn lint\"",
     "compile": "tsc -b",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "clean": "rimraf lib *.tsbuildinfo",
-    "test": "TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register",
-    "test:watch": "TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register --watch",
+    "test": "cross-env TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register",
+    "test:watch": "cross-env TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register --watch",
     "test:compiled": "mocha --exit --reporter spec \"./lib/**/*.spec.js\"",
     "lint": "eslint --ext \".js,.ts\" src",
     "build": "concurrently -n compile,lint -c blue,green \"yarn compile\" \"yarn lint\"",
@@ -60,6 +60,7 @@
     "@typescript-eslint/parser": "^5.3.1",
     "chai": "^4.3.4",
     "concurrently": "^6.4.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.2.0",
     "husky": "4.x.x",
     "mocha": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clean": "rimraf lib *.tsbuildinfo",
     "test": "TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register",
     "test:watch": "TS_NODE_PROJECT=./tsconfig.json mocha --exit --watch-files \"./src/**/*.ts\" --reporter spec \"./src/**/*.spec.ts\" --require source-map-support/register --require ts-node/register --watch",
+    "test:compiled": "mocha --exit --reporter spec \"./lib/**/*.spec.js\"",
     "lint": "eslint --ext \".js,.ts\" src",
     "build": "concurrently -n compile,lint -c blue,green \"yarn compile\" \"yarn lint\"",
     "compile": "tsc -b",
@@ -32,7 +33,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint && yarn build && yarn test",
+      "pre-commit": "yarn lint && yarn build && yarn test:compiled",
       "post-merge": "yarn"
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,7 +484,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Allows to watch files for changes and re-run the tests and doesn't
require manual re-build before each test.