### PR TITLE
fix: help users resolve no valid tsserver version error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Maintained by a [community of contributors](https://github.com/typescript-langua
 ## Installing
 
 ```sh
-npm install -g typescript-language-server
+npm install -g typescript-language-server typescript
 ```
 
 ## Running the language server

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -174,7 +174,7 @@ export class LspServer {
         if (typescriptVersion) {
             this.logger.info(`Using Typescript version (${typescriptVersion.source}) ${typescriptVersion.versionString} from path "${typescriptVersion.tsServerPath}"`);
         } else {
-            throw Error('Could not find a valid tsserver version on $PATH. Please install tsserver with `npm install -g typescript`. Exiting.');
+            throw Error('Could not find a valid tsserver executable in the workspace or in the $PATH. Please ensure that the "typescript" dependency is installed in either location. Exiting.');
         }
 
         this.tspClient = new TspClient({

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -174,7 +174,7 @@ export class LspServer {
         if (typescriptVersion) {
             this.logger.info(`Using Typescript version (${typescriptVersion.source}) ${typescriptVersion.versionString} from path "${typescriptVersion.tsServerPath}"`);
         } else {
-            throw Error('Could not find a valid tsserver version. Exiting.');
+            throw Error('Could not find a valid tsserver version on $PATH. Please install tsserver with `npm install -g typescript`. Exiting.');
         }
 
         this.tspClient = new TspClient({


### PR DESCRIPTION
Not all users will already have typescript installed (or they may have done something like switching to a new nodejs install via asdf that doesn't have typescript installed). Also since tsserver is a dependency of typescript-language-server I added it to the readme.

Related: https://github.com/typescript-language-server/typescript-language-server/issues/28
Fixes #336