### PR TITLE
fix: don't use the postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "compile": "tsc -b",
     "watch": "tsc -b --watch --verbose",
     "postversion": "git push --follow-tags",
-    "postinstall": "cd test-data/jsx && yarn"
+    "prepare": "cd test-data/jsx && yarn"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
The script also runs when the user installs the package with
`npm -i g typescript-language-server` so we can't use it.