### PR TITLE
fix: wait for tsserver configuration requests to finish

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -211,25 +211,26 @@ export class LspServer {
 
         this.typeScriptAutoFixProvider = new TypeScriptAutoFixProvider(this.tspClient);
 
-        this.tspClient.request(CommandTypes.Configure, {
-            ...hostInfo ? { hostInfo } : {},
-            formatOptions: {
-                // We can use \n here since the editor should normalize later on to its line endings.
-                newLineCharacter: '\n'
-            },
-            preferences
-        });
-
-        this.tspClient.request(CommandTypes.CompilerOptionsForInferredProjects, {
-            options: {
-                module: tsp.ModuleKind.CommonJS,
-                target: tsp.ScriptTarget.ES2016,
-                jsx: tsp.JsxEmit.Preserve,
-                allowJs: true,
-                allowSyntheticDefaultImports: true,
-                allowNonTsExtensions: true
-            }
-        });
+        await Promise.all([
+            this.tspClient.request(CommandTypes.Configure, {
+                ...hostInfo ? { hostInfo } : {},
+                formatOptions: {
+                    // We can use \n here since the editor should normalize later on to its line endings.
+                    newLineCharacter: '\n'
+                },
+                preferences
+            }),
+            this.tspClient.request(CommandTypes.CompilerOptionsForInferredProjects, {
+                options: {
+                    module: tsp.ModuleKind.CommonJS,
+                    target: tsp.ScriptTarget.ES2016,
+                    jsx: tsp.JsxEmit.Preserve,
+                    allowJs: true,
+                    allowSyntheticDefaultImports: true,
+                    allowNonTsExtensions: true
+                }
+            })
+        ]);
 
         const logFileUri = logFile && pathToUri(logFile, undefined);
         this.initializeResult = {


### PR DESCRIPTION
Fix delayed `$/progress` begin event (https://github.com/typescript-language-server/typescript-language-server/pull/326). This is a work-around for https://github.com/microsoft/TypeScript/issues/47465. AFAIK, this is how vscode does it too.

Here's a demo of it correctly sending the "Initializing JS/TS language features ..." event.

![tty](https://user-images.githubusercontent.com/943597/149673600-5187fbec-d1ce-4243-b4b8-2aaba5cf3a2d.gif)

Here's what I used for testing https://gist.github.com/icholy/23670692d6405e676611fa49081a5f06