### PR TITLE
feat: send $/progress reports every 500 milliseconds

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -43,6 +43,7 @@ import { CodeActionKind } from './utils/types';
 class ServerInitializingIndicator {
     private _loadingProjectName?: string;
     private _progressReporter?: ProgressReporter;
+    private _reportInterval?: NodeJS.Timeout;
 
     constructor(private lspClient: LspClient) {}
 
@@ -54,6 +55,10 @@ class ServerInitializingIndicator {
                 this._progressReporter = undefined;
             }
         }
+        if (this._reportInterval) {
+            clearInterval(this._reportInterval);
+            this._reportInterval = undefined;
+        }
     }
 
     public startedLoadingProject(projectName: string): void {
@@ -64,15 +69,14 @@ class ServerInitializingIndicator {
         this._loadingProjectName = projectName;
         this._progressReporter = this.lspClient.createProgressReporter();
         this._progressReporter.begin('Initializing JS/TS language features…');
+        this._reportInterval = setInterval(() => {
+            this._progressReporter?.report('In Progress');
+        }, 500);
     }
 
     public finishedLoadingProject(projectName: string): void {
         if (this._loadingProjectName === projectName) {
-            this._loadingProjectName = undefined;
-            if (this._progressReporter) {
-                this._progressReporter.end();
-                this._progressReporter = undefined;
-            }
+            this.reset();
         }
     }
 }


### PR DESCRIPTION
tsserver doesn't send progress reports when loading a project. This change sends a "In Progress" report every 500 milliseconds between `startedLoadingProject` and `finishedLoadingProject`. These are often used to update the UI in LSP clients. For example, [lsp_progress](https://github.com/arkav/lualine-lsp-progress) uses it to advance the spinner.

![tty](https://user-images.githubusercontent.com/943597/149679494-462d3ebe-b671-482e-bac0-f4fe658c91c0.gif)

I'm not convinced it's worth it, but I was curious what you thought.
 