### PR TITLE
fix: call configure before completion resolve 

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -582,6 +582,10 @@ export class LspServer {
             throw new Error('The document should be opened for completion, file: ' + file);
         }
 
+        await this.tspClient.request(CommandTypes.Configure, {
+            formatOptions: this.getWorkspacePreferencesForDocument(file).format
+        });
+
         try {
             const result = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionInfo, {
                 file,

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -582,10 +582,6 @@ export class LspServer {
             throw new Error('The document should be opened for completion, file: ' + file);
         }
 
-        await this.tspClient.request(CommandTypes.Configure, {
-            formatOptions: this.getWorkspacePreferencesForDocument(file).format
-        });
-
         try {
             const result = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionInfo, {
                 file,
@@ -609,6 +605,9 @@ export class LspServer {
 
     async completionResolve(item: lsp.CompletionItem): Promise<lsp.CompletionItem> {
         this.logger.log('completion/resolve', item);
+        await this.tspClient.request(CommandTypes.Configure, {
+            formatOptions: this.getWorkspacePreferencesForDocument(item.data.file).format
+        });
         const { body } = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionDetails, item.data));
         const details = body && body.length && body[0];
         if (!details) {


### PR DESCRIPTION
Auto import doesn't use insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces formatting option