### PR TITLE
fix: don't transform Yarn zipfile URIs

### DIFF
--- a/src/protocol-translation.ts
+++ b/src/protocol-translation.ts
@@ -20,18 +20,13 @@ export function uriToPath(stringUri: string): string | undefined {
     return normalizeFsPath(uri.fsPath);
 }
 
-function parsePathOrUri(filepath: string): URI {
+export function pathToUri(filepath: string, documents: LspDocuments | undefined): string {
     // handles valid URIs from yarn pnp, will error if doesn't have scheme
     // zipfile:/foo/bar/baz.zip::path/to/module
     if (filepath.startsWith('zipfile:')) {
-        return URI.parse(filepath);
+        return filepath;
     }
-    // handles valid filepaths from everything else /path/to/module
-    return URI.file(filepath);
-}
-
-export function pathToUri(filepath: string, documents: LspDocuments | undefined): string {
-    const fileUri = parsePathOrUri(filepath);
+    const fileUri = URI.file(filepath);
     const normalizedFilepath = normalizePath(fileUri.fsPath);
     const document = documents && documents.get(normalizedFilepath);
     return document ? document.uri : fileUri.toString();


### PR DESCRIPTION
It appears the `URI.parse()` and `uri.toString()` dance on `zipfile:` URIs is causing escaping that's confusing my Neovim. (specifically the `::` separator, and newer Neovim requires `zipfile:///path...` instead of `zipfile:/path...`) Considering these URIs are (always?) produced by Yarn v2+, I think we can simply trust them without transformation?