### PR TITLE
fix: don't transform zipfile URIs from Vim

### DIFF
--- a/src/protocol-translation.ts
+++ b/src/protocol-translation.ts
@@ -13,6 +13,11 @@ import { LspDocuments } from './document';
 const RE_PATHSEP_WINDOWS = /\\/g;
 
 export function uriToPath(stringUri: string): string | undefined {
+    // Vim may send `zipfile:` URIs which tsserver with Yarn v2+ hook can handle. Keep as-is.
+    // Example: zipfile:///foo/bar/baz.zip::path/to/module
+    if (stringUri.startsWith('zipfile:')) {
+        return stringUri;
+    }
     const uri = URI.parse(stringUri);
     if (uri.scheme !== 'file') {
         return undefined;
@@ -21,8 +26,8 @@ export function uriToPath(stringUri: string): string | undefined {
 }
 
 export function pathToUri(filepath: string, documents: LspDocuments | undefined): string {
-    // handles valid URIs from yarn pnp, will error if doesn't have scheme
-    // zipfile:/foo/bar/baz.zip::path/to/module
+    // Yarn v2+ hooks tsserver and sends `zipfile:` URIs for Vim. Keep as-is.
+    // Example: zipfile:///foo/bar/baz.zip::path/to/module
     if (filepath.startsWith('zipfile:')) {
         return filepath;
     }


### PR DESCRIPTION
Sorry for the churn on this.

With the fix from #384 in place, I was able to follow a type definition from a regular file into a zipfile. But I wasn't able to take a second step / follow any definitions inside *that* file.

Turns out this is quite obvious. The Yarn hook transfoms VsCode-style zip paths sent by tsserver into Vim-style zip paths, and #384 ensured those weren't mangled by typescript-language-server. So, tsserver could hint Vim about a definition somewhere in a zip file, and Vim could open that file. But then, the opposite happens when Vim opens the file: Vim sends a `textDocument/didOpen` (among others) with a Vim-style zip path in the `uri` field, which typescript-language-server was still mangling, and so the Yarn hook is unable to transform that back to a VsCode-style zip path for tsserver.

I just hope I'm not bypassing any required path normalisations here. I did brief testing and was now able to navigate around, at least.

I made a small change to the comments here to hopefully make the situation more clear. There's also a recent change in Vim that changed zip paths from `zipfile:/path...` to `zipfile:///path...`, and I updated the example to reflect that. (But that change doesn't affect our actual code.)