### PR TITLE
feat: add support for rename prefixText and suffixText

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -679,7 +679,7 @@ export class LspServer {
 
                 spanGroup.locs.forEach((textSpan) => {
                     textEdits.push({
-                        newText: params.newName,
+                        newText: `${textSpan.prefixText || ''}${params.newName}${textSpan.suffixText || ''}`,
                         range: {
                             start: toPosition(textSpan.start),
                             end: toPosition(textSpan.end)


### PR DESCRIPTION
The server supports setting `providePrefixAndSuffixTextForRename`, which may return `prefixText` or `suffixText` as part of the rename response. These values are currently being ignored.

Example:

```ts
import { useState } from "react";
```

Renaming `useState` to `useStateTest` with `providePrefixAndSuffixTextForRename` set to `true` currently results in the following:

```ts
import { useStateTest } from "react";
```

This is an error since `useStateTest` is not defined. After this change, renaming results in:

```ts
import { useState as useStateTest } from "react";
```

I didn't see any tests for rename, but can add some if necessary.