### PR TITLE
fix: completion for strings with trigger character

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -103,7 +103,11 @@ export function asCompletionItem(entry: tsp.CompletionEntry, file: string, posit
             }
         }
     }
-    if (insertText && replacementRange) {
+    if (replacementRange) {
+        if (!insertText) {
+            insertText = item.label;
+        }
+
         item.textEdit = lsp.TextEdit.replace(replacementRange, insertText);
     } else {
         item.insertText = insertText;

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -377,3 +377,20 @@ function asDetail({ displayParts, sourceDisplay, source: deprecatedSource }: tsp
     }
     return result.join('\n');
 }
+
+export function getCompletionTriggerCharacter(character: string | undefined): tsp.CompletionsTriggerCharacter | undefined {
+    switch (character) {
+        case '@':
+        case '#':
+        case ' ':
+        case '.':
+        case '"':
+        case '\'':
+        case '`':
+        case '/':
+        case '<':
+            return character;
+        default:
+            return undefined;
+    }
+}

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -25,7 +25,7 @@ import {
     pathToUri, toTextEdit, toFileRangeRequestArgs, asPlainText, normalizePath
 } from './protocol-translation';
 import { LspDocuments, LspDocument } from './document';
-import { asCompletionItem, asResolvedCompletionItem } from './completion';
+import { asCompletionItem, asResolvedCompletionItem, getCompletionTriggerCharacter } from './completion';
 import { asSignatureHelp } from './hover';
 import { Commands } from './commands';
 import { provideQuickFix } from './quickfix';
@@ -588,7 +588,9 @@ export class LspServer {
             const result = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionInfo, {
                 file,
                 line: params.position.line + 1,
-                offset: params.position.character + 1
+                offset: params.position.character + 1,
+                triggerCharacter: getCompletionTriggerCharacter(params.context?.triggerCharacter),
+                triggerKind: params.context?.triggerKind
             }));
             const { body } = result;
             const completions = (body ? body.entries : [])


### PR DESCRIPTION
# Pull Request

When trying to type a string with a trigger character the autocompletion does not return a testEdit, causing editors to append the text resulting in duplication and unwanted behaviour.

## Explanation

Had a completion result with the following content:

```json
{
   "name": "hello/world",
   "kind": "string",
   "kindModifiers": "",
   "sortText": "11",
   "replacementSpan": {
      "start": {
         "line": 9,
         "offset": 11
      },
      "end": {
         "line": 9,
         "offset": 12
      }
   }
}
```

Got transformed into:

```json
{
   "label":"hello/world",
   "kind":21,
   "sortText":"11",
   "data":{
      "file":"/Users/jasper/projects/codesandbox/pitcher/packages/pitcher-agent/workspace/codesandbox/test-sandbox/draft/priceless-curran/pages/_app.tsx",
      "line":9,
      "offset":12,
      "entryNames":[
         "hello/world"
      ]
   }
}
```

But the correct one is:

```json
{
   "label":"hello/world",
   "kind":21,
   "sortText":"11",
   "data":{
      "file":"/Users/jasper/projects/codesandbox/pitcher/packages/pitcher-agent/workspace/codesandbox/test-sandbox/draft/priceless-curran/pages/_app.tsx",
      "line":9,
      "offset":12,
      "entryNames":[
         "hello/world"
      ]
   },
   "textEdit":{
      "range":{
         "start":{
            "line":8,
            "character":10
         },
         "end":{
            "line":8,
            "character":11
         }
      },
      "newText":"hello/world"
   }
}
```

Code to reproduce this:

```ts
function test(value: "fs/read" | "hello/world") {
  return true;
}

test("fs/")
```

When the cursor is after `test("fs/` and tries to autocomplete it fails causing `test("fs/fs/read")` instead of `test("fs/read")`