### PR TITLE
chore(ci): drop node 12 and add node 18 testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     runs-on: ${{ matrix.os }}
     env:
       CI: true


### PR DESCRIPTION
This doesn't drop node 12 compatibility (not yet at least) but stops testing node 12.

Feature dependency updates unfortunately will break node 12 support.