### PR TITLE
fix: handle shutdown lifecycle properly

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,7 +1,7 @@
 require:
     - 'source-map-support/register'
     - 'ts-node/register'
-spec: './src/**/lsp-server.spec.ts'
+spec: './src/**/*.spec.ts'
 # Set to 0 to disable timeout when debugging.
 timeout: 20000
 watch-files: './src/**/*.ts'

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,8 +1,7 @@
-exit: true
 require:
     - 'source-map-support/register'
     - 'ts-node/register'
-spec: './src/**/*.spec.ts'
+spec: './src/**/lsp-server.spec.ts'
 # Set to 0 to disable timeout when debugging.
 timeout: 10000
 watch-files: './src/**/*.ts'

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -3,5 +3,5 @@ require:
     - 'ts-node/register'
 spec: './src/**/lsp-server.spec.ts'
 # Set to 0 to disable timeout when debugging.
-timeout: 10000
+timeout: 20000
 watch-files: './src/**/*.ts'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib *.tsbuildinfo",
     "test": "cross-env CONSOLE_LOG_LEVEL=warn TS_NODE_PROJECT=./tsconfig.json mocha",
     "test:watch": "cross-env CONSOLE_LOG_LEVEL=warn TS_NODE_PROJECT=./tsconfig.json mocha --watch",
-    "test:compiled": "CONSOLE_LOG_LEVEL=warn mocha \"./lib/**/*.spec.js\"",
+    "test:compiled": "cross-env CONSOLE_LOG_LEVEL=warn mocha \"./lib/**/*.spec.js\"",
     "lint": "eslint --ext \".js,.ts\" src",
     "build": "concurrently -n compile,lint -c blue,green \"yarn compile\" \"yarn lint\"",
     "compile": "tsc -b",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib *.tsbuildinfo",
     "test": "cross-env CONSOLE_LOG_LEVEL=warn TS_NODE_PROJECT=./tsconfig.json mocha",
     "test:watch": "cross-env CONSOLE_LOG_LEVEL=warn TS_NODE_PROJECT=./tsconfig.json mocha --watch",
-    "test:compiled": "mocha \"./lib/**/*.spec.js\"",
+    "test:compiled": "CONSOLE_LOG_LEVEL=warn mocha \"./lib/**/*.spec.js\"",
     "lint": "eslint --ext \".js,.ts\" src",
     "build": "concurrently -n compile,lint -c blue,green \"yarn compile\" \"yarn lint\"",
     "compile": "tsc -b",

--- a/src/file-lsp-server.spec.ts
+++ b/src/file-lsp-server.spec.ts
@@ -19,8 +19,14 @@ before(async () => {
         publishDiagnostics: () => { }
     });
 });
+
 beforeEach(() => {
     server.closeAll();
+});
+
+after(() => {
+    server.closeAll();
+    server.shutdown();
 });
 
 describe('documentHighlight', () => {

--- a/src/tsp-client.spec.ts
+++ b/src/tsp-client.spec.ts
@@ -15,10 +15,17 @@ import { TypeScriptVersionProvider } from './utils/versionProvider';
 const assert = chai.assert;
 const typescriptVersionProvider = new TypeScriptVersionProvider();
 const bundled = typescriptVersionProvider.bundledVersion();
+let server: TspClient;
 
-const server = new TspClient({
-    logger: new ConsoleLogger(),
-    tsserverPath: bundled!.tsServerPath
+before(() => {
+    server = new TspClient({
+        logger: new ConsoleLogger(),
+        tsserverPath: bundled!.tsServerPath
+    });
+});
+
+after(() => {
+    server.shutdown();
 });
 
 describe('ts server client', () => {


### PR DESCRIPTION
Remove forced process exit from mocha configuration which was a way to workaround the issue with the server process not being explicitly shut down and destroy tsserver client and lsp server properly.

This can also affect non-test use-cases but hopefully not for the worse.

The issue with the original problem was that:
a) the server didn't cleanly shut itself down
b) whenever the tsserver was closed (either due to `shutdown` call or just crashed) the code would also force-exit the LS server process. This was typically OK but it wasn't clean and could be problematic for those who'd want to use the server programmatically and not force-close their process when server closes.