### PR TITLE
fix: declare quickfix/refactor CodeAction capabilities

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -303,7 +303,12 @@ export class LspServer {
                     resolveProvider: true
                 },
                 codeActionProvider: clientCapabilities.textDocument?.codeAction?.codeActionLiteralSupport
-                    ? { codeActionKinds: [...TypeScriptAutoFixProvider.kinds.map(kind => kind.value), CodeActionKind.SourceOrganizeImportsTs.value] } : true,
+                    ? { codeActionKinds: [
+                        ...TypeScriptAutoFixProvider.kinds.map(kind => kind.value),
+                        CodeActionKind.SourceOrganizeImportsTs.value,
+                        CodeActionKind.QuickFix.value,
+                        CodeActionKind.Refactor.value
+                    ] } : true,
                 definitionProvider: true,
                 documentFormattingProvider: true,
                 documentRangeFormattingProvider: true,


### PR DESCRIPTION
There was a bug in monaco-languageclient, (droping codeAction provider metadata), which was making this issue invisible.
The issue is now fixed and quickfix code actions are not working anymore with this LSP implementation because it doesn't declare the quickfix codeAction capability, even though it's able to handle them.