### PR TITLE
feat: support communicating with tsserver using IPC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,42 @@
+Parts of the code copied from the https://github.com/microsoft/vscode repository are licensed under the following license:
+
+BEGIN LICENSE ----------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2015 - present Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+END LICESE -------------------------------------------------------------------
+
+This applies to files that include the following license header:
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+The rest of the code licensed under:
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -158,7 +158,8 @@ describe('completion', () => {
         });
         const pos = position(doc, 'foo');
         const proposals = await server.completion({ textDocument: doc, position: pos });
-        assert.isNull(proposals);
+        assert.isNotNull(proposals);
+        assert.strictEqual(proposals?.items.length, 0);
         server.didCloseTextDocument({ textDocument: doc });
     });
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -105,7 +105,7 @@ export function toPlatformEOL(text: string): string {
     return text;
 }
 
-class TestLspClient implements LspClient {
+export class TestLspClient implements LspClient {
     private workspaceEditsListener: ((args: lsp.ApplyWorkspaceEditParams) => void) | null = null;
 
     constructor(protected options: TestLspServerOptions, protected logger: ConsoleLogger) {}
@@ -124,11 +124,11 @@ class TestLspClient implements LspClient {
         return await task(progress);
     }
 
-    publishDiagnostics(args: lsp.PublishDiagnosticsParams) {
+    publishDiagnostics(args: lsp.PublishDiagnosticsParams): void {
         return this.options.publishDiagnostics(args);
     }
 
-    showErrorMessage(message: string) {
+    showErrorMessage(message: string): void {
         this.logger.error(`[showErrorMessage] ${message}`);
     }
 
@@ -147,7 +147,7 @@ class TestLspClient implements LspClient {
         return { applied: true };
     }
 
-    async rename() {
+    rename(): Promise<void> {
         throw new Error('unsupported');
     }
 }

--- a/src/tsServer/callbackMap.ts
+++ b/src/tsServer/callbackMap.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type tsp from 'typescript/lib/protocol.d.js';
+import { ServerResponse } from './requests.js';
+
+export interface CallbackItem<R> {
+    readonly onSuccess: (value: R) => void;
+    readonly onError: (err: Error) => void;
+    readonly queuingStartTime: number;
+    readonly isAsync: boolean;
+}
+
+export class CallbackMap<R extends tsp.Response> {
+    private readonly _callbacks = new Map<number, CallbackItem<ServerResponse.Response<R> | undefined>>();
+    private readonly _asyncCallbacks = new Map<number, CallbackItem<ServerResponse.Response<R> | undefined>>();
+
+    public destroy(cause: string): void {
+        const cancellation = new ServerResponse.Cancelled(cause);
+        for (const callback of this._callbacks.values()) {
+            callback.onSuccess(cancellation);
+        }
+        this._callbacks.clear();
+        for (const callback of this._asyncCallbacks.values()) {
+            callback.onSuccess(cancellation);
+        }
+        this._asyncCallbacks.clear();
+    }
+
+    public add(seq: number, callback: CallbackItem<ServerResponse.Response<R> | undefined>, isAsync: boolean): void {
+        if (isAsync) {
+            this._asyncCallbacks.set(seq, callback);
+        } else {
+            this._callbacks.set(seq, callback);
+        }
+    }
+
+    public fetch(seq: number): CallbackItem<ServerResponse.Response<R> | undefined> | undefined {
+        const callback = this._callbacks.get(seq) || this._asyncCallbacks.get(seq);
+        this.delete(seq);
+        return callback;
+    }
+
+    private delete(seq: number) {
+        if (!this._callbacks.delete(seq)) {
+            this._asyncCallbacks.delete(seq);
+        }
+    }
+}

--- a/src/tsServer/cancellation.ts
+++ b/src/tsServer/cancellation.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import fs from 'node:fs';
+import { temporaryFile } from 'tempy';
+// import Tracer from '../utils/tracer';
+
+export interface OngoingRequestCanceller {
+    readonly cancellationPipeName: string | undefined;
+    tryCancelOngoingRequest(seq: number): boolean;
+}
+
+export interface OngoingRequestCancellerFactory {
+    create(serverId: string/*, tracer: Tracer*/): OngoingRequestCanceller;
+}
+
+const noopRequestCanceller = new class implements OngoingRequestCanceller {
+    public readonly cancellationPipeName = undefined;
+
+    public tryCancelOngoingRequest(_seq: number): boolean {
+        return false;
+    }
+};
+
+export const noopRequestCancellerFactory = new class implements OngoingRequestCancellerFactory {
+    create(_serverId: string/*, _tracer: Tracer*/): OngoingRequestCanceller {
+        return noopRequestCanceller;
+    }
+};
+
+export class NodeRequestCanceller implements OngoingRequestCanceller {
+    public readonly cancellationPipeName: string;
+
+    public constructor(
+        // private readonly _serverId: string,
+        // private readonly _tracer: Tracer,
+    ) {
+        this.cancellationPipeName = temporaryFile({ name: 'tscancellation' });
+    }
+
+    public tryCancelOngoingRequest(seq: number): boolean {
+        if (!this.cancellationPipeName) {
+            return false;
+        }
+        // this._tracer.logTrace(this._serverId, `TypeScript Server: trying to cancel ongoing request with sequence number ${seq}`);
+        try {
+            fs.writeFileSync(this.cancellationPipeName + String(seq), '');
+        } catch {
+            // noop
+        }
+        return true;
+    }
+}
+
+export const nodeRequestCancellerFactory = new class implements OngoingRequestCancellerFactory {
+    create(/*serverId: string, tracer: Tracer*/): OngoingRequestCanceller {
+        return new NodeRequestCanceller(/*serverId, tracer*/);
+    }
+};

--- a/src/tsServer/cancellation.ts
+++ b/src/tsServer/cancellation.ts
@@ -19,7 +19,7 @@ export interface OngoingRequestCanceller {
 }
 
 export interface OngoingRequestCancellerFactory {
-    create(serverId: string/*, tracer: Tracer*/): OngoingRequestCanceller;
+    create(/*serverId: string, tracer: Tracer*/): OngoingRequestCanceller;
 }
 
 const noopRequestCanceller = new class implements OngoingRequestCanceller {
@@ -31,7 +31,7 @@ const noopRequestCanceller = new class implements OngoingRequestCanceller {
 };
 
 export const noopRequestCancellerFactory = new class implements OngoingRequestCancellerFactory {
-    create(_serverId: string/*, _tracer: Tracer*/): OngoingRequestCanceller {
+    create(/*_serverId: string, _tracer: Tracer*/): OngoingRequestCanceller {
         return noopRequestCanceller;
     }
 };

--- a/src/tsServer/requestQueue.ts
+++ b/src/tsServer/requestQueue.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type tsp from 'typescript/lib/protocol.d.js';
+
+export enum RequestQueueingType {
+    /**
+     * Normal request that is executed in order.
+     */
+    Normal = 1,
+
+    /**
+     * Request that normal requests jump in front of in the queue.
+     */
+    LowPriority = 2,
+
+    /**
+     * A fence that blocks request reordering.
+     *
+     * Fences are not reordered. Unlike a normal request, a fence will never jump in front of a low priority request
+     * in the request queue.
+     */
+    Fence = 3,
+}
+
+export interface RequestItem {
+    readonly request: tsp.Request;
+    readonly expectsResponse: boolean;
+    readonly isAsync: boolean;
+    readonly queueingType: RequestQueueingType;
+}
+
+export class RequestQueue {
+    private readonly queue: RequestItem[] = [];
+    private sequenceNumber = 0;
+
+    public get length(): number {
+        return this.queue.length;
+    }
+
+    public enqueue(item: RequestItem): void {
+        if (item.queueingType === RequestQueueingType.Normal) {
+            let index = this.queue.length - 1;
+            while (index >= 0) {
+                if (this.queue[index].queueingType !== RequestQueueingType.LowPriority) {
+                    break;
+                }
+                --index;
+            }
+            this.queue.splice(index + 1, 0, item);
+        } else {
+            // Only normal priority requests can be reordered. All other requests just go to the end.
+            this.queue.push(item);
+        }
+    }
+
+    public dequeue(): RequestItem | undefined {
+        return this.queue.shift();
+    }
+
+    public tryDeletePendingRequest(seq: number): boolean {
+        for (let i = 0; i < this.queue.length; i++) {
+            if (this.queue[i].request.seq === seq) {
+                this.queue.splice(i, 1);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public createRequest(command: string, args: any): tsp.Request {
+        return {
+            seq: this.sequenceNumber++,
+            type: 'request',
+            command: command,
+            arguments: args,
+        };
+    }
+}

--- a/src/tsServer/requests.ts
+++ b/src/tsServer/requests.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import vscodeUri from 'vscode-uri';
+import type tsp from 'typescript/lib/protocol.d.js';
+import { CommandTypes } from '../tsp-command-types.js';
+import { ExecutionTarget } from './server.js';
+
+export enum ServerType {
+    Syntax = 'syntax',
+    Semantic = 'semantic',
+}
+
+export namespace ServerResponse {
+
+    export class Cancelled {
+        public readonly type = 'cancelled';
+
+        constructor(
+            public readonly reason: string,
+        ) { }
+    }
+
+    export const NoContent = { type: 'noContent' } as const;
+
+    export const NoServer = { type: 'noServer' } as const;
+
+    export type Response<T extends tsp.Response> = T | Cancelled | typeof NoContent | typeof NoServer;
+}
+
+export interface TypeScriptRequestTypes {
+    [CommandTypes.ApplyCodeActionCommand]: [tsp.ApplyCodeActionCommandRequestArgs, tsp.ApplyCodeActionCommandResponse];
+    [CommandTypes.Change]: [tsp.ChangeRequestArgs, null];
+    [CommandTypes.Close]: [tsp.FileRequestArgs, null];
+    [CommandTypes.CompilerOptionsForInferredProjects]: [tsp.SetCompilerOptionsForInferredProjectsArgs, tsp.SetCompilerOptionsForInferredProjectsResponse];
+    [CommandTypes.CompletionDetails]: [tsp.CompletionDetailsRequestArgs, tsp.CompletionDetailsResponse];
+    [CommandTypes.CompletionInfo]: [tsp.CompletionsRequestArgs, tsp.CompletionInfoResponse];
+    [CommandTypes.Configure]: [tsp.ConfigureRequestArguments, tsp.ConfigureResponse];
+    [CommandTypes.Definition]: [tsp.FileLocationRequestArgs, tsp.DefinitionResponse];
+    [CommandTypes.DefinitionAndBoundSpan]: [tsp.FileLocationRequestArgs, tsp.DefinitionInfoAndBoundSpanResponse];
+    [CommandTypes.DocCommentTemplate]: [tsp.FileLocationRequestArgs, tsp.DocCommandTemplateResponse];
+    [CommandTypes.DocumentHighlights]: [tsp.DocumentHighlightsRequestArgs, tsp.DocumentHighlightsResponse];
+    [CommandTypes.EncodedSemanticClassificationsFull]: [tsp.EncodedSemanticClassificationsRequestArgs, tsp.EncodedSemanticClassificationsResponse];
+    [CommandTypes.FindSourceDefinition]: [tsp.FileLocationRequestArgs, tsp.DefinitionResponse];
+    [CommandTypes.Format]: [tsp.FormatRequestArgs, tsp.FormatResponse];
+    [CommandTypes.Formatonkey]: [tsp.FormatOnKeyRequestArgs, tsp.FormatResponse];
+    [CommandTypes.GetApplicableRefactors]: [tsp.GetApplicableRefactorsRequestArgs, tsp.GetApplicableRefactorsResponse];
+    [CommandTypes.GetCodeFixes]: [tsp.CodeFixRequestArgs, tsp.CodeFixResponse];
+    [CommandTypes.GetCombinedCodeFix]: [tsp.GetCombinedCodeFixRequestArgs, tsp.GetCombinedCodeFixResponse];
+    [CommandTypes.GetEditsForFileRename]: [tsp.GetEditsForFileRenameRequestArgs, tsp.GetEditsForFileRenameResponse];
+    [CommandTypes.GetEditsForRefactor]: [tsp.GetEditsForRefactorRequestArgs, tsp.GetEditsForRefactorResponse];
+    [CommandTypes.Geterr]: [tsp.GeterrRequestArgs, any];
+    [CommandTypes.GetOutliningSpans]: [tsp.FileRequestArgs, tsp.OutliningSpansResponse];
+    [CommandTypes.GetSupportedCodeFixes]: [null, tsp.GetSupportedCodeFixesResponse];
+    [CommandTypes.Implementation]: [tsp.FileLocationRequestArgs, tsp.ImplementationResponse];
+    [CommandTypes.JsxClosingTag]: [tsp.JsxClosingTagRequestArgs, tsp.JsxClosingTagResponse];
+    [CommandTypes.Navto]: [tsp.NavtoRequestArgs, tsp.NavtoResponse];
+    [CommandTypes.NavTree]: [tsp.FileRequestArgs, tsp.NavTreeResponse];
+    [CommandTypes.Open]: [tsp.OpenRequestArgs, null];
+    [CommandTypes.OrganizeImports]: [tsp.OrganizeImportsRequestArgs, tsp.OrganizeImportsResponse];
+    [CommandTypes.ProjectInfo]: [tsp.ProjectInfoRequestArgs, tsp.ProjectInfoResponse];
+    [CommandTypes.ProvideInlayHints]: [tsp.InlayHintsRequestArgs, tsp.InlayHintsResponse];
+    [CommandTypes.Quickinfo]: [tsp.FileLocationRequestArgs, tsp.QuickInfoResponse];
+    [CommandTypes.References]: [tsp.FileLocationRequestArgs, tsp.ReferencesResponse];
+    [CommandTypes.Rename]: [tsp.RenameRequestArgs, tsp.RenameResponse];
+    [CommandTypes.SignatureHelp]: [tsp.SignatureHelpRequestArgs, tsp.SignatureHelpResponse];
+    [CommandTypes.TypeDefinition]: [tsp.FileLocationRequestArgs, tsp.TypeDefinitionResponse];
+    [CommandTypes.UpdateOpen]: [tsp.UpdateOpenRequestArgs, tsp.Response];
+}
+
+export type ExecConfig = {
+    readonly lowPriority?: boolean;
+    readonly nonRecoverable?: boolean;
+    readonly cancelOnResourceChange?: vscodeUri.URI;
+    readonly executionTarget?: ExecutionTarget;
+};
+

--- a/src/tsServer/server.ts
+++ b/src/tsServer/server.ts
@@ -1,0 +1,295 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type tsp from 'typescript/lib/protocol.d.js';
+import { CancellationToken } from 'vscode-jsonrpc';
+import { RequestItem, RequestQueue, RequestQueueingType } from './requestQueue.js';
+import { ServerResponse, ServerType, TypeScriptRequestTypes } from './requests.js';
+import type { TspClientOptions } from '../tsp-client.js';
+import { OngoingRequestCanceller } from './cancellation.js';
+import { CallbackMap } from './callbackMap.js';
+import { TypeScriptServerError } from './serverError.js';
+import type { TypeScriptVersion } from './versionProvider.js';
+
+export enum ExecutionTarget {
+    Semantic,
+    Syntax
+}
+
+export interface TypeScriptServerExitEvent {
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+}
+
+type OnEventHandler = (e: tsp.Event) => any;
+type OnExitHandler = (e: TypeScriptServerExitEvent) => any;
+type OnErrorHandler = (e: any) => any;
+
+export interface ITypeScriptServer {
+    onEvent(handler: OnEventHandler): void;
+    onExit(handler: OnExitHandler): void;
+    onError(handler: OnErrorHandler): void;
+
+    readonly tsServerLogFile: string | undefined;
+
+    kill(): void;
+
+    /**
+     * @return A list of all execute requests. If there are multiple entries, the first item is the primary
+     * request while the rest are secondary ones.
+     */
+    executeImpl(command: keyof TypeScriptRequestTypes, args: any, executeInfo: { isAsync: boolean; token?: CancellationToken; expectsResult: boolean; lowPriority?: boolean; executionTarget?: ExecutionTarget; }): Array<Promise<ServerResponse.Response<tsp.Response>> | undefined>;
+
+    dispose(): void;
+}
+
+export const enum TsServerProcessKind {
+    Main = 'main',
+    Syntax = 'syntax',
+    Semantic = 'semantic',
+    Diagnostics = 'diagnostics'
+}
+
+export interface TsServerProcessFactory {
+    fork(
+        version: TypeScriptVersion,
+        args: readonly string[],
+        kind: TsServerProcessKind,
+        configuration: TspClientOptions,
+    ): TsServerProcess;
+}
+
+export interface TsServerProcess {
+    write(serverRequest: tsp.Request): void;
+
+    onData(handler: (data: tsp.Response) => void): void;
+    onExit(handler: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+    onError(handler: (error: Error) => void): void;
+
+    kill(): void;
+}
+
+export class ProcessBasedTsServer implements ITypeScriptServer {
+    private readonly _requestQueue = new RequestQueue();
+    private readonly _callbacks = new CallbackMap<tsp.Response>();
+    private readonly _pendingResponses = new Set<number>();
+    private readonly _eventHandlers = new Set<OnEventHandler>();
+    private readonly _exitHandlers = new Set<OnExitHandler>();
+    private readonly _errorHandlers = new Set<OnErrorHandler>();
+
+    constructor(
+        private readonly _serverId: string,
+        private readonly _serverSource: ServerType,
+        private readonly _process: TsServerProcess,
+        private readonly _tsServerLogFile: string | undefined,
+        private readonly _requestCanceller: OngoingRequestCanceller,
+        private readonly _version: TypeScriptVersion,
+        // private readonly _tracer: Tracer,
+    ) {
+        this._process.onData(msg => {
+            this.dispatchMessage(msg);
+        });
+
+        this._process.onExit((code, signal) => {
+            this._exitHandlers.forEach(handler => handler({ code, signal }));
+            this._callbacks.destroy('server exited');
+        });
+
+        this._process.onError(error => {
+            this._errorHandlers.forEach(handler => handler(error));
+            this._callbacks.destroy('server errored');
+        });
+    }
+
+    public onEvent(handler: OnEventHandler): void {
+        this._eventHandlers.add(handler);
+    }
+
+    public onExit(handler: OnExitHandler): void {
+        this._exitHandlers.add(handler);
+    }
+
+    public onError(handler: OnErrorHandler): void {
+        this._errorHandlers.add(handler);
+    }
+
+    public get tsServerLogFile(): string | undefined {
+        return this._tsServerLogFile;
+    }
+
+    private write(serverRequest: tsp.Request) {
+        this._process.write(serverRequest);
+    }
+
+    public dispose(): void {
+        this._callbacks.destroy('server disposed');
+        this._pendingResponses.clear();
+        this._eventHandlers.clear();
+        this._exitHandlers.clear();
+        this._errorHandlers.clear();
+    }
+
+    public kill(): void {
+        this.dispose();
+        this._process.kill();
+    }
+
+    private dispatchMessage(message: tsp.Message) {
+        try {
+            switch (message.type) {
+                case 'response':
+                    if (this._serverSource) {
+                        this.dispatchResponse({
+                            ...(message as tsp.Response),
+                        });
+                    } else {
+                        this.dispatchResponse(message as tsp.Response);
+                    }
+                    break;
+
+                case 'event': {
+                    const event = message as tsp.Event;
+                    if (event.event === 'requestCompleted') {
+                        const seq = (event as tsp.RequestCompletedEvent).body.request_seq;
+                        const callback = this._callbacks.fetch(seq);
+                        if (callback) {
+                            // this._tracer.traceRequestCompleted(this._serverId, 'requestCompleted', seq, callback);
+                            callback.onSuccess(undefined);
+                        }
+                    } else {
+                        // this._tracer.traceEvent(this._serverId, event);
+                        this._eventHandlers.forEach(handler => handler(event));
+                    }
+                    break;
+                }
+                default:
+                    throw new Error(`Unknown message type ${message.type} received`);
+            }
+        } finally {
+            this.sendNextRequests();
+        }
+    }
+
+    private tryCancelRequest(seq: number, command: string): boolean {
+        try {
+            if (this._requestQueue.tryDeletePendingRequest(seq)) {
+                this.logTrace(`Canceled request with sequence number ${seq}`);
+                return true;
+            }
+
+            if (this._requestCanceller.tryCancelOngoingRequest(seq)) {
+                return true;
+            }
+
+            this.logTrace(`Tried to cancel request with sequence number ${seq}. But request got already delivered.`);
+            return false;
+        } finally {
+            const callback = this.fetchCallback(seq);
+            callback?.onSuccess(new ServerResponse.Cancelled(`Cancelled request ${seq} - ${command}`));
+        }
+    }
+
+    private dispatchResponse(response: tsp.Response) {
+        const callback = this.fetchCallback(response.request_seq);
+        if (!callback) {
+            return;
+        }
+
+        // this._tracer.traceResponse(this._serverId, response, callback);
+        if (response.success) {
+            callback.onSuccess(response);
+        } else if (response.message === 'No content available.') {
+            // Special case where response itself is successful but there is not any data to return.
+            callback.onSuccess(ServerResponse.NoContent);
+        } else {
+            callback.onError(TypeScriptServerError.create(this._serverId, this._version, response));
+        }
+    }
+
+    public executeImpl(command: keyof TypeScriptRequestTypes, args: any, executeInfo: { isAsync: boolean; token?: CancellationToken; expectsResult: boolean; lowPriority?: boolean; executionTarget?: ExecutionTarget; }): Array<Promise<ServerResponse.Response<tsp.Response>> | undefined> {
+        const request = this._requestQueue.createRequest(command, args);
+        const requestInfo: RequestItem = {
+            request,
+            expectsResponse: executeInfo.expectsResult,
+            isAsync: executeInfo.isAsync,
+            queueingType: ProcessBasedTsServer.getQueueingType(command, executeInfo.lowPriority),
+        };
+        let result: Promise<ServerResponse.Response<tsp.Response>> | undefined;
+        if (executeInfo.expectsResult) {
+            result = new Promise<ServerResponse.Response<tsp.Response>>((resolve, reject) => {
+                this._callbacks.add(request.seq, { onSuccess: resolve as () => ServerResponse.Response<tsp.Response> | undefined, onError: reject, queuingStartTime: Date.now(), isAsync: executeInfo.isAsync }, executeInfo.isAsync);
+
+                if (executeInfo.token) {
+                    executeInfo.token.onCancellationRequested(() => {
+                        this.tryCancelRequest(request.seq, command);
+                    });
+                }
+            });
+        }
+
+        this._requestQueue.enqueue(requestInfo);
+        this.sendNextRequests();
+
+        return [result];
+    }
+
+    private sendNextRequests(): void {
+        // console.error({ pending: this._pendingResponses.size, queue: this._requestQueue.length });
+        while (this._pendingResponses.size === 0 && this._requestQueue.length > 0) {
+            const item = this._requestQueue.dequeue();
+            if (item) {
+                this.sendRequest(item);
+            }
+        }
+    }
+
+    private sendRequest(requestItem: RequestItem): void {
+        const serverRequest = requestItem.request;
+        // this._tracer.traceRequest(this._serverId, serverRequest, requestItem.expectsResponse, this._requestQueue.length);
+
+        if (requestItem.expectsResponse && !requestItem.isAsync) {
+            this._pendingResponses.add(requestItem.request.seq);
+        }
+
+        try {
+            this.write(serverRequest);
+        } catch (err) {
+            const callback = this.fetchCallback(serverRequest.seq);
+            callback?.onError(err as Error);
+        }
+    }
+
+    private fetchCallback(seq: number) {
+        const callback = this._callbacks.fetch(seq);
+        if (!callback) {
+            return undefined;
+        }
+
+        this._pendingResponses.delete(seq);
+        return callback;
+    }
+
+    private logTrace(_message: string) {
+        // this._tracer.logTrace(this._serverId, message);
+    }
+
+    private static readonly fenceCommands = new Set(['change', 'close', 'open', 'updateOpen']);
+
+    private static getQueueingType(
+        command: string,
+        lowPriority?: boolean,
+    ): RequestQueueingType {
+        if (ProcessBasedTsServer.fenceCommands.has(command)) {
+            return RequestQueueingType.Fence;
+        }
+        return lowPriority ? RequestQueueingType.LowPriority : RequestQueueingType.Normal;
+    }
+}

--- a/src/tsServer/serverError.ts
+++ b/src/tsServer/serverError.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type tsp from 'typescript/lib/protocol.d.js';
+import type { TypeScriptVersion } from './versionProvider.js';
+
+export class TypeScriptServerError extends Error {
+    public static create(
+        serverId: string,
+        version: TypeScriptVersion,
+        response: tsp.Response,
+    ): TypeScriptServerError {
+        const parsedResult = TypeScriptServerError.parseErrorText(response);
+        return new TypeScriptServerError(serverId, version, response, parsedResult?.message, parsedResult?.stack);
+    }
+
+    private constructor(
+        public readonly serverId: string,
+        public readonly version: TypeScriptVersion,
+        private readonly response: tsp.Response,
+        public readonly serverMessage: string | undefined,
+        public readonly serverStack: string | undefined,
+    ) {
+        super(`<${serverId}> TypeScript Server Error (${version.versionString})\n${serverMessage}\n${serverStack}`);
+    }
+
+    public get serverErrorText(): string | undefined {
+        return this.response.message;
+    }
+
+    public get serverCommand(): string {
+        return this.response.command;
+    }
+
+    /**
+     * Given a `errorText` from a tsserver request indicating failure in handling a request.
+     */
+    private static parseErrorText(response: tsp.Response) {
+        const errorText = response.message;
+        if (errorText) {
+            const errorPrefix = 'Error processing request. ';
+            if (errorText.startsWith(errorPrefix)) {
+                const prefixFreeErrorText = errorText.substr(errorPrefix.length);
+                const newlineIndex = prefixFreeErrorText.indexOf('\n');
+                if (newlineIndex >= 0) {
+                    // Newline expected between message and stack.
+                    const stack = prefixFreeErrorText.substring(newlineIndex + 1);
+                    return {
+                        message: prefixFreeErrorText.substring(0, newlineIndex),
+                        stack,
+                    };
+                }
+            }
+        }
+        return undefined;
+    }
+}

--- a/src/tsServer/serverProcess.ts
+++ b/src/tsServer/serverProcess.ts
@@ -1,0 +1,279 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import ChildProcess from 'node:child_process';
+import path from 'node:path';
+import type { Readable } from 'node:stream';
+import type tsp from 'typescript/lib/protocol.d.js';
+import { TsServerProcess, TsServerProcessFactory, TsServerProcessKind } from './server.js';
+import type { TspClientOptions } from '../tsp-client.js';
+import API from '../utils/api.js';
+import type { TypeScriptVersion } from './versionProvider.js';
+
+export class NodeTsServerProcessFactory implements TsServerProcessFactory {
+    fork(
+        version: TypeScriptVersion,
+        args: readonly string[],
+        kind: TsServerProcessKind,
+        configuration: TspClientOptions,
+    ): TsServerProcess {
+        const tsServerPath = version.tsServerPath;
+        const useIpc = version.version?.gte(API.v460);
+
+        const runtimeArgs = [...args];
+        if (useIpc) {
+            runtimeArgs.push('--useNodeIpc');
+        }
+
+        const childProcess = ChildProcess.fork(tsServerPath, runtimeArgs, {
+            silent: true,
+            cwd: undefined,
+            env: generatePatchedEnv(process.env, tsServerPath),
+            execArgv: getExecArgv(kind, configuration),
+            stdio: useIpc ? ['pipe', 'pipe', 'pipe', 'ipc'] : undefined,
+        });
+
+        return useIpc ? new IpcChildServerProcess(childProcess) : new StdioChildServerProcess(childProcess);
+    }
+}
+
+function generatePatchedEnv(env: any, modulePath: string): any {
+    const newEnv = Object.assign({}, env);
+    newEnv.NODE_PATH = path.join(modulePath, '..', '..', '..');
+    // Ensure we always have a PATH set
+    newEnv.PATH = newEnv.PATH || process.env.PATH;
+    return newEnv;
+}
+
+function getExecArgv(kind: TsServerProcessKind, configuration: TspClientOptions): string[] {
+    const args: string[] = [];
+    const debugPort = getDebugPort(kind);
+    if (debugPort) {
+        const inspectFlag = getTssDebugBrk() ? '--inspect-brk' : '--inspect';
+        args.push(`${inspectFlag}=${debugPort}`);
+    }
+    if (configuration.maxTsServerMemory) {
+        args.push(`--max-old-space-size=${configuration.maxTsServerMemory}`);
+    }
+    return args;
+}
+
+function getDebugPort(kind: TsServerProcessKind): number | undefined {
+    if (kind === TsServerProcessKind.Syntax) {
+        // We typically only want to debug the main semantic server
+        return undefined;
+    }
+    const value = getTssDebugBrk() || getTssDebug();
+    if (value) {
+        const port = parseInt(value);
+        if (!isNaN(port)) {
+            return port;
+        }
+    }
+    return undefined;
+}
+
+function getTssDebug(): string | undefined {
+    return process.env.TSS_DEBUG;
+}
+
+function getTssDebugBrk(): string | undefined {
+    return process.env.TSS_DEBUG_BRK;
+}
+
+class IpcChildServerProcess implements TsServerProcess {
+    constructor(
+        private readonly _process: ChildProcess.ChildProcess,
+    ) {}
+
+    write(serverRequest: tsp.Request): void {
+        this._process.send(serverRequest);
+    }
+
+    onData(handler: (data: tsp.Response) => void): void {
+        this._process.on('message', handler);
+    }
+
+    onExit(handler: (code: number | null, signal: NodeJS.Signals | null) => void): void {
+        this._process.on('exit', handler);
+    }
+
+    onError(handler: (err: Error) => void): void {
+        this._process.on('error', handler);
+    }
+
+    kill(): void {
+        this._process.kill();
+    }
+}
+
+class StdioChildServerProcess implements TsServerProcess {
+    private _reader: Reader<tsp.Response> | null;
+
+    constructor(
+        private readonly _process: ChildProcess.ChildProcess,
+    ) {
+        this._reader = new Reader<tsp.Response>(this._process.stdout!);
+    }
+
+    private get reader(): Reader<tsp.Response> {
+        return this._reader!;
+    }
+
+    write(serverRequest: tsp.Request): void {
+        this._process.stdin!.write(JSON.stringify(serverRequest) + '\r\n', 'utf8');
+    }
+
+    onData(handler: (data: tsp.Response) => void): void {
+        this.reader.onData(handler);
+    }
+
+    onExit(handler: (code: number | null, signal: NodeJS.Signals | null) => void): void {
+        this._process.on('exit', handler);
+    }
+
+    onError(handler: (err: Error) => void): void {
+        this._process.on('error', handler);
+        this.reader.onError(handler);
+    }
+
+    kill(): void {
+        this._process.kill();
+        this.reader.dispose();
+        this._reader = null;
+    }
+}
+
+class Reader<T> {
+    private readonly buffer: ProtocolBuffer = new ProtocolBuffer();
+    private nextMessageLength = -1;
+    private _onError = (_error: Error) => {};
+    private _onData = (_data: T) => {};
+    private isDisposed = false;
+
+    public constructor(readable: Readable) {
+        readable.on('data', data => this.onLengthData(data));
+    }
+
+    public dispose() {
+        this.isDisposed = true;
+        this._onError = (_error: Error) => {};
+        this._onData = (_data: T) => {};
+    }
+
+    public onError(handler: (error: Error) => void): void {
+        this._onError = handler;
+    }
+
+    public onData(handler: (data: T) => void): void {
+        this._onData = handler;
+    }
+
+    private onLengthData(data: Buffer | string): void {
+        if (this.isDisposed) {
+            return;
+        }
+
+        try {
+            this.buffer.append(data);
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+                if (this.nextMessageLength === -1) {
+                    this.nextMessageLength = this.buffer.tryReadContentLength();
+                    if (this.nextMessageLength === -1) {
+                        return;
+                    }
+                }
+                const msg = this.buffer.tryReadContent(this.nextMessageLength);
+                if (msg === null) {
+                    return;
+                }
+                this.nextMessageLength = -1;
+                const json = JSON.parse(msg);
+                this._onData(json);
+            }
+        } catch (e) {
+            this._onError(e as Error);
+        }
+    }
+}
+
+const defaultSize = 8192;
+const contentLength = 'Content-Length: ';
+const contentLengthSize: number = Buffer.byteLength(contentLength, 'utf8');
+const blank: number = Buffer.from(' ', 'utf8')[0];
+const backslashR: number = Buffer.from('\r', 'utf8')[0];
+const backslashN: number = Buffer.from('\n', 'utf8')[0];
+
+class ProtocolBuffer {
+    private index = 0;
+    private buffer: Buffer = Buffer.allocUnsafe(defaultSize);
+
+    public append(data: string | Buffer): void {
+        let toAppend: Buffer | null = null;
+        if (Buffer.isBuffer(data)) {
+            toAppend = data;
+        } else {
+            toAppend = Buffer.from(data, 'utf8');
+        }
+        if (this.buffer.length - this.index >= toAppend.length) {
+            toAppend.copy(this.buffer, this.index, 0, toAppend.length);
+        } else {
+            const newSize = (Math.ceil((this.index + toAppend.length) / defaultSize) + 1) * defaultSize;
+            if (this.index === 0) {
+                this.buffer = Buffer.allocUnsafe(newSize);
+                toAppend.copy(this.buffer, 0, 0, toAppend.length);
+            } else {
+                this.buffer = Buffer.concat([this.buffer.slice(0, this.index), toAppend], newSize);
+            }
+        }
+        this.index += toAppend.length;
+    }
+
+    public tryReadContentLength(): number {
+        let result = -1;
+        let current = 0;
+        // we are utf8 encoding...
+        while (current < this.index && (this.buffer[current] === blank || this.buffer[current] === backslashR || this.buffer[current] === backslashN)) {
+            current++;
+        }
+        if (this.index < current + contentLengthSize) {
+            return result;
+        }
+        current += contentLengthSize;
+        const start = current;
+        while (current < this.index && this.buffer[current] !== backslashR) {
+            current++;
+        }
+        if (current + 3 >= this.index || this.buffer[current + 1] !== backslashN || this.buffer[current + 2] !== backslashR || this.buffer[current + 3] !== backslashN) {
+            return result;
+        }
+        const data = this.buffer.toString('utf8', start, current);
+        result = parseInt(data);
+        this.buffer = this.buffer.slice(current + 4);
+        this.index = this.index - (current + 4);
+        return result;
+    }
+
+    public tryReadContent(length: number): string | null {
+        if (this.index < length) {
+            return null;
+        }
+        const result = this.buffer.toString('utf8', 0, length);
+        let sourceStart = length;
+        while (sourceStart < this.index && (this.buffer[sourceStart] === backslashR || this.buffer[sourceStart] === backslashN)) {
+            sourceStart++;
+        }
+        this.buffer.copy(this.buffer, 0, sourceStart);
+        this.index = this.index - sourceStart;
+        return result;
+    }
+}

--- a/src/tsServer/spawner.ts
+++ b/src/tsServer/spawner.ts
@@ -1,0 +1,154 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2017, 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import API from '../utils/api.js';
+import { ServerType } from './requests.js';
+import { Logger } from '../logger.js';
+import type { TspClientOptions } from '../tsp-client.js';
+import { nodeRequestCancellerFactory } from './cancellation.js';
+import { ITypeScriptServer, ProcessBasedTsServer, TsServerProcessKind } from './server.js';
+import { NodeTsServerProcessFactory } from './serverProcess.js';
+import type { TypeScriptVersion } from './versionProvider.js';
+
+export class TypeScriptServerSpawner {
+    public constructor(
+        private readonly _apiVersion: API,
+        // private readonly _logDirectoryProvider: ILogDirectoryProvider,
+        private readonly _logger: Logger,
+    ) { }
+
+    public spawn(
+        version: TypeScriptVersion,
+        configuration: TspClientOptions,
+    ): ITypeScriptServer {
+        const kind = TsServerProcessKind.Main;
+        const processFactory = new NodeTsServerProcessFactory();
+        const canceller = nodeRequestCancellerFactory.create(/*kind, this._tracer*/);
+        const { args, tsServerLogFile } = this.getTsServerArgs(TsServerProcessKind.Main, configuration, this._apiVersion, canceller.cancellationPipeName);
+        const process = processFactory.fork(version, args, TsServerProcessKind.Main, configuration);
+        this._logger.log('Starting tsserver');
+        return new ProcessBasedTsServer(
+            kind,
+            this.kindToServerType(kind),
+            process,
+            tsServerLogFile,
+            canceller,
+            version,
+            /*this._telemetryReporter,
+            this._tracer*/);
+    }
+
+    private kindToServerType(kind: TsServerProcessKind): ServerType {
+        switch (kind) {
+            case TsServerProcessKind.Syntax:
+                return ServerType.Syntax;
+
+            case TsServerProcessKind.Main:
+            case TsServerProcessKind.Semantic:
+            case TsServerProcessKind.Diagnostics:
+            default:
+                return ServerType.Semantic;
+        }
+    }
+
+    private getTsServerArgs(
+        kind: TsServerProcessKind,
+        configuration: TspClientOptions,
+        // currentVersion: TypeScriptVersion,
+        apiVersion: API,
+        cancellationPipeName: string | undefined,
+    ): { args: string[]; tsServerLogFile: string | undefined; tsServerTraceDirectory: string | undefined; } {
+        const args: string[] = [];
+        let tsServerLogFile: string | undefined;
+        let tsServerTraceDirectory: string | undefined;
+
+        if (kind === TsServerProcessKind.Syntax) {
+            if (apiVersion.gte(API.v401)) {
+                args.push('--serverMode', 'partialSemantic');
+            } else {
+                args.push('--syntaxOnly');
+            }
+        }
+
+        if (apiVersion.gte(API.v250)) {
+            args.push('--useInferredProjectPerProjectRoot');
+        } else {
+            args.push('--useSingleInferredProject');
+        }
+
+        const {
+            disableAutomaticTypingAcquisition,
+            globalPlugins,
+            locale,
+            logFile,
+            logVerbosity,
+            npmLocation,
+            pluginProbeLocations,
+        } = configuration;
+        if (disableAutomaticTypingAcquisition || kind === TsServerProcessKind.Syntax || kind === TsServerProcessKind.Diagnostics) {
+            args.push('--disableAutomaticTypingAcquisition');
+        }
+        // if (kind === TsServerProcessKind.Semantic || kind === TsServerProcessKind.Main) {
+        //     args.push('--enableTelemetry');
+        // }
+        if (cancellationPipeName) {
+            args.push('--cancellationPipeName', cancellationPipeName + '*');
+        }
+        // if (TspClient.isLoggingEnabled(configuration)) {
+        //     const logDir = this._logDirectoryProvider.getNewLogDirectory();
+        //     if (logDir) {
+        //         tsServerLogFile = path.join(logDir, 'tsserver.log');
+        //         args.push('--logVerbosity', TsServerLogLevel.toString(configuration.tsServerLogLevel));
+        //         args.push('--logFile', tsServerLogFile);
+        //     }
+        // }
+        if (logFile) {
+            args.push('--logFile', logFile);
+        }
+        if (logVerbosity) {
+            args.push('--logVerbosity', logVerbosity);
+        }
+        // if (configuration.enableTsServerTracing) {
+        //     tsServerTraceDirectory = this._logDirectoryProvider.getNewLogDirectory();
+        //     if (tsServerTraceDirectory) {
+        //         args.push('--traceDirectory', tsServerTraceDirectory);
+        //     }
+        // }
+        // const pluginPaths = this._pluginPathsProvider.getPluginPaths();
+        // if (pluginManager.plugins.length) {
+        //     args.push('--globalPlugins', pluginManager.plugins.map(x => x.name).join(','));
+        //     const isUsingBundledTypeScriptVersion = currentVersion.path === this._versionProvider.defaultVersion.path;
+        //     for (const plugin of pluginManager.plugins) {
+        //         if (isUsingBundledTypeScriptVersion || plugin.enableForWorkspaceTypeScriptVersions) {
+        //             pluginPaths.push(isWeb() ? plugin.uri.toString() : plugin.uri.fsPath);
+        //         }
+        //     }
+        // }
+        // if (pluginPaths.length !== 0) {
+        //     args.push('--pluginProbeLocations', pluginPaths.join(','));
+        // }
+        if (globalPlugins && globalPlugins.length) {
+            args.push('--globalPlugins', globalPlugins.join(','));
+        }
+        if (pluginProbeLocations && pluginProbeLocations.length) {
+            args.push('--pluginProbeLocations', pluginProbeLocations.join(','));
+        }
+        if (npmLocation) {
+            this._logger.info(`using npm from ${npmLocation}`);
+            args.push('--npmLocation', `"${npmLocation}"`);
+        }
+        args.push('--locale', locale || 'en');
+        // args.push('--noGetErrOnBackgroundUpdate');
+        args.push('--validateDefaultNpmLocation');
+        return { args, tsServerLogFile, tsServerTraceDirectory };
+    }
+}
+

--- a/src/tsp-client.spec.ts
+++ b/src/tsp-client.spec.ts
@@ -8,21 +8,26 @@
 import * as chai from 'chai';
 import { TspClient } from './tsp-client.js';
 import { ConsoleLogger } from './logger.js';
-import { filePath, readContents } from './test-utils.js';
+import { filePath, readContents, TestLspClient, uri } from './test-utils.js';
 import { CommandTypes } from './tsp-command-types.js';
-import API from './utils/api.js';
 import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
 
 const assert = chai.assert;
 const typescriptVersionProvider = new TypeScriptVersionProvider();
 const bundled = typescriptVersionProvider.bundledVersion();
+const logger = new ConsoleLogger();
+const lspClientOptions = {
+    rootUri: uri(),
+    publishDiagnostics: () => { },
+};
+const lspClient = new TestLspClient(lspClientOptions, logger);
 let server: TspClient;
 
 before(() => {
     server = new TspClient({
-        apiVersion: API.defaultVersion,
-        logger: new ConsoleLogger(),
-        tsserverPath: bundled!.tsServerPath,
+        logger,
+        lspClient,
+        typescriptVersion: bundled!,
     });
 });
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -34,6 +34,7 @@ export default class API {
     public static readonly v420 = API.fromSimpleString('4.2.0');
     public static readonly v430 = API.fromSimpleString('4.3.0');
     public static readonly v440 = API.fromSimpleString('4.4.0');
+    public static readonly v460 = API.fromSimpleString('4.6.0');
     public static readonly v470 = API.fromSimpleString('4.7.0');
 
     public static fromVersionString(versionString: string): API {


### PR DESCRIPTION
Ported a bunch of code from "VSCode typescript features" to enable us to be able to communicate with `tsserver` over IPC instead of `stdio`. IPC is used for tsserver (typescript) versions 4.60+, otherwise the legacy stdio is used.

If this seems like a lot of code to handle that case then yes, it is, but it's part of the plan to align the code as closely as possible with VSCode to be able to support features like #358 without re-inventing the wheel.