### PR TITLE
feat: add "tsserver.trace" init option for tracing tsserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The `tsserver` setting specifies additional options related to the internal `tss
 interface TsserverOptions {
     /**
      * The verbosity of logging of the tsserver communication.
-     * Delivered through the LSP messages and doesn't affect file logging.
+     * Delivered through the LSP messages and not related to file logging.
      * @default 'off'
      */
     trace?: 'off' | 'messages' | 'verbose';

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ The language server accepts various settings through the `initializationOptions`
 | locale            | string   | The locale to use to show error messages. |
 | plugins           | object[] | An array of `{ name: string, location: string }` objects for registering a Typescript plugins. **Default**: []                                                                                                                                                         |
 | preferences       | object   | Preferences passed to the Typescript (`tsserver`) process. See below for more info.                                                                                                                              |
+| tsserver          | object   | Options related to the `tsserver` process. See below for more info.                                                                                                                              |
+
+The `tsserver` setting specifies additional options related to the internal `tsserver` process, like tracing and logging.
+
+```ts
+interface TsserverOptions {
+    /**
+     * The verbosity of logging of the tsserver communication.
+     * Delivered through the LSP messages and doesn't affect file logging.
+     * @default 'off'
+     */
+    trace?: 'off' | 'messages' | 'verbose';
+}
+```
 
 The `preferences` object is an object specifying preferences for the internal `tsserver` process. Those options depend on the version of Typescript used but at the time of writing Typescript v4.4.3 contains these options:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,8 +8,8 @@
 
 import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
+import lsp from 'vscode-languageserver';
 import { createLspConnection } from './lsp-connection.js';
-import * as lsp from 'vscode-languageserver';
 
 const DEFAULT_LOG_LEVEL = lsp.MessageType.Info;
 const { version } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), { encoding: 'utf8' }));

--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -8,7 +8,7 @@
 import type tsp from 'typescript/lib/protocol.d.js';
 import * as lsp from 'vscode-languageserver';
 import debounce from 'p-debounce';
-import { Logger } from './logger.js';
+import { Logger } from './utils/logger.js';
 import { pathToUri, toDiagnostic } from './protocol-translation.js';
 import { EventTypes } from './tsp-command-types.js';
 import { LspDocuments } from './document.js';

--- a/src/lsp-connection.ts
+++ b/src/lsp-connection.ts
@@ -5,21 +5,21 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import * as lsp from 'vscode-languageserver/node.js';
+import lsp from 'vscode-languageserver/node.js';
 import * as lspcalls from './lsp-protocol.calls.proposed.js';
 import * as lspinlayHints from './lsp-protocol.inlayHints.proposed.js';
-import { LspClientLogger } from './logger.js';
+import { LspClientLogger } from './utils/logger.js';
 import { LspServer } from './lsp-server.js';
 import { LspClientImpl } from './lsp-client.js';
 
-export interface IServerOptions {
+export interface LspConnectionOptions {
     tsserverPath: string;
     tsserverLogFile?: string;
     tsserverLogVerbosity?: string;
     showMessageLevel: lsp.MessageType;
 }
 
-export function createLspConnection(options: IServerOptions): lsp.Connection {
+export function createLspConnection(options: LspConnectionOptions): lsp.Connection {
     const connection = lsp.createConnection(lsp.ProposedFeatures.all);
     const lspClient = new LspClientImpl(connection);
     const logger = new LspClientLogger(lspClient, options.showMessageLevel);

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -10,6 +10,7 @@
  */
 import * as lsp from 'vscode-languageserver-protocol';
 import type tsp from 'typescript/lib/protocol.d.js';
+import type { TraceValue } from './tsServer/tracer.js';
 
 export namespace TypeScriptRenameRequest {
     export const type = new lsp.RequestType<lsp.TextDocumentPositionParams, void, void>('_typescript.rename');
@@ -40,13 +41,23 @@ export interface TypeScriptPlugin {
 
 export interface TypeScriptInitializationOptions {
     disableAutomaticTypingAcquisition?: boolean;
+    hostInfo?: string;
+    locale?: string;
     logVerbosity?: string;
     maxTsServerMemory?: number;
     npmLocation?: string;
-    locale?: string;
     plugins: TypeScriptPlugin[];
     preferences?: tsp.UserPreferences;
-    hostInfo?: string;
+    tsserver?: TsserverOptions;
+}
+
+interface TsserverOptions {
+    /**
+     * The verbosity of logging the tsserver communication through the LSP messages.
+     * This doesn't affect the file logging.
+     * @default 'off'
+     */
+    trace?: TraceValue;
 }
 
 export type TypeScriptInitializeParams = lsp.InitializeParams & {

--- a/src/tsServer/tracer.ts
+++ b/src/tsServer/tracer.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-unnecessary-qualifier */
+
+import type tsp from 'typescript/lib/protocol.d.js';
+import { Logger } from '../utils/logger.js';
+
+export enum Trace {
+    Off,
+    Messages,
+    Verbose,
+}
+
+export type TraceValue = 'off' | 'messages' | 'verbose';
+
+export namespace Trace {
+    export function fromString(value: string): Trace {
+        value = value.toLowerCase();
+        switch (value) {
+            case 'off':
+                return Trace.Off;
+            case 'messages':
+                return Trace.Messages;
+            case 'verbose':
+                return Trace.Verbose;
+            default:
+                return Trace.Off;
+        }
+    }
+}
+
+interface RequestExecutionMetadata {
+    readonly queuingStartTime: number;
+}
+
+export default class Tracer {
+    constructor(
+        private readonly logger: Logger,
+        private readonly trace: Trace,
+    ) {
+    }
+
+    public traceRequest(serverId: string, request: tsp.Request, responseExpected: boolean, queueLength: number): void {
+        if (this.trace === Trace.Off) {
+            return;
+        }
+        let data: string | undefined = undefined;
+        if (this.trace === Trace.Verbose && request.arguments) {
+            data = `Arguments: ${JSON.stringify(request.arguments, null, 4)}`;
+        }
+        this.logTrace(serverId, `Sending request: ${request.command} (${request.seq}). Response expected: ${responseExpected ? 'yes' : 'no'}. Current queue length: ${queueLength}`, data);
+    }
+
+    public traceResponse(serverId: string, response: tsp.Response, meta: RequestExecutionMetadata): void {
+        if (this.trace === Trace.Off) {
+            return;
+        }
+        let data: string | undefined = undefined;
+        if (this.trace === Trace.Verbose && response.body) {
+            data = `Result: ${JSON.stringify(response.body, null, 4)}`;
+        }
+        this.logTrace(serverId, `Response received: ${response.command} (${response.request_seq}). Request took ${Date.now() - meta.queuingStartTime} ms. Success: ${response.success} ${!response.success ? `. Message: ${response.message}` : ''}`, data);
+    }
+
+    public traceRequestCompleted(serverId: string, command: string, request_seq: number, meta: RequestExecutionMetadata): any {
+        if (this.trace === Trace.Off) {
+            return;
+        }
+        this.logTrace(serverId, `Async response received: ${command} (${request_seq}). Request took ${Date.now() - meta.queuingStartTime} ms.`);
+    }
+
+    public traceEvent(serverId: string, event: tsp.Event): void {
+        if (this.trace === Trace.Off) {
+            return;
+        }
+        let data: string | undefined = undefined;
+        if (this.trace === Trace.Verbose && event.body) {
+            data = `Data: ${JSON.stringify(event.body, null, 4)}`;
+        }
+        this.logTrace(serverId, `Event received: ${event.event} (${event.seq}).`, data);
+    }
+
+    public logTrace(serverId: string, message: string, data?: any): void {
+        if (this.trace !== Trace.Off) {
+            this.logger.trace('Trace', `<${serverId}> ${message}`, data);
+        }
+    }
+}

--- a/src/tsServer/versionProvider.ts
+++ b/src/tsServer/versionProvider.ts
@@ -2,15 +2,22 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import which from 'which';
 import { pkgUpSync } from 'pkg-up';
 import API from '../utils/api.js';
-import type { IServerOptions } from '../utils/configuration.js';
+import type { TypeScriptServiceConfiguration } from '../utils/configuration.js';
 import { findPathToModule } from '../utils/modules-resolver.js';
-import type { Logger } from '../logger.js';
+import type { Logger } from '../utils/logger.js';
 
 export const enum TypeScriptVersionSource {
     Bundled = 'bundled',
@@ -105,10 +112,10 @@ export class TypeScriptVersion {
 export const MODULE_FOLDERS = ['node_modules/typescript/lib', '.vscode/pnpify/typescript/lib', '.yarn/sdks/typescript/lib'];
 
 export class TypeScriptVersionProvider {
-    public constructor(private configuration?: IServerOptions, private logger?: Logger) {}
+    public constructor(private configuration: TypeScriptServiceConfiguration, private logger?: Logger) {}
 
     public getUserSettingVersion(): TypeScriptVersion | null {
-        const { tsserverPath } = this.configuration || {};
+        const { tsserverPath } = this.configuration;
         if (!tsserverPath) {
             return null;
         }

--- a/src/tsp-client.spec.ts
+++ b/src/tsp-client.spec.ts
@@ -7,26 +7,32 @@
 
 import * as chai from 'chai';
 import { TspClient } from './tsp-client.js';
-import { ConsoleLogger } from './logger.js';
+import { ConsoleLogger } from './utils/logger.js';
 import { filePath, readContents, TestLspClient, uri } from './test-utils.js';
 import { CommandTypes } from './tsp-command-types.js';
+import { Trace } from './tsServer/tracer.js';
 import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
+import { TypeScriptServiceConfiguration } from './utils/configuration.js';
 
 const assert = chai.assert;
-const typescriptVersionProvider = new TypeScriptVersionProvider();
-const bundled = typescriptVersionProvider.bundledVersion();
 const logger = new ConsoleLogger();
 const lspClientOptions = {
     rootUri: uri(),
     publishDiagnostics: () => { },
 };
 const lspClient = new TestLspClient(lspClientOptions, logger);
+const configuration: TypeScriptServiceConfiguration = {
+    logger,
+    lspClient,
+};
+const typescriptVersionProvider = new TypeScriptVersionProvider(configuration);
+const bundled = typescriptVersionProvider.bundledVersion();
 let server: TspClient;
 
 before(() => {
     server = new TspClient({
-        logger,
-        lspClient,
+        ...configuration,
+        trace: Trace.Off,
         typescriptVersion: bundled!,
     });
 });

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -4,13 +4,13 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-import { Logger } from '../logger.js';
-import { LspClient } from '../lsp-client.js';
+import type { Logger } from '../utils/logger.js';
+import type { LspClient } from '../lsp-client.js';
 
-export interface IServerOptions {
-    logger: Logger;
-    tsserverPath?: string;
-    tsserverLogFile?: string;
-    tsserverLogVerbosity?: string;
-    lspClient: LspClient;
+export interface TypeScriptServiceConfiguration {
+    readonly logger: Logger;
+    readonly lspClient: LspClient;
+    readonly tsserverLogFile?: string;
+    readonly tsserverLogVerbosity?: string;
+    readonly tsserverPath?: string;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 /*
  * Copyright (C) 2017, 2018 TypeFox and others.
  *
@@ -5,24 +9,27 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { LspClient } from './lsp-client.js';
-import * as lsp from 'vscode-languageserver';
+import lsp from 'vscode-languageserver';
+import type { LspClient } from '../lsp-client.js';
 
-/**
- * the logger type
- */
+type TraceLevel = 'Trace' | 'Info' | 'Error';
+
 export interface Logger {
     error(...arg: any[]): void;
     warn(...arg: any[]): void;
     info(...arg: any[]): void;
     log(...arg: any[]): void;
+    /**
+     * Logs the arguments regardless of the logging level.
+     */
+    trace(...arg: any[]): void;
 }
 
 export class LspClientLogger implements Logger {
     constructor(protected client: LspClient, protected level: lsp.MessageType) { }
 
-    protected sendMessage(severity: lsp.MessageType, messageObjects: any[]): void {
-        if (this.level >= severity) {
+    protected sendMessage(severity: lsp.MessageType, messageObjects: any[], options?: { overrideLevel?: boolean; }): void {
+        if (this.level >= severity || options?.overrideLevel) {
             const message = messageObjects.map(p => {
                 if (typeof p === 'object') {
                     return JSON.stringify(p, null, 2);
@@ -52,6 +59,10 @@ export class LspClientLogger implements Logger {
 
     log(...arg: any[]): void {
         this.sendMessage(lsp.MessageType.Log, arg);
+    }
+
+    trace(...arg: any[]): void {
+        this.sendMessage(lsp.MessageType.Log, arg, { overrideLevel: true });
     }
 }
 
@@ -102,6 +113,9 @@ export class ConsoleLogger implements Logger {
     log(...arg: any[]): void {
         this.print('error', lsp.MessageType.Log, arg);
     }
+    trace(...arg: any[]): void {
+        this.log(arg);
+    }
 }
 
 export class PrefixingLogger implements Logger {
@@ -122,4 +136,32 @@ export class PrefixingLogger implements Logger {
     log(...arg: any[]): void {
         this.logger.log(this.prefix, ...arg);
     }
+
+    trace(level: TraceLevel, message: string, data?: any): void {
+        this.logger.trace(this.prefix, `[${level}  - ${now()}] ${message}`);
+        if (data) {
+            this.logger.trace(this.prefix, data2String(data));
+        }
+    }
+}
+
+function now(): string {
+    const now = new Date();
+    return padLeft(`${now.getUTCHours()}`, 2, '0')
+            + ':' + padLeft(`${now.getMinutes()}`, 2, '0')
+            + ':' + padLeft(`${now.getUTCSeconds()}`, 2, '0') + `.${now.getMilliseconds()}`;
+}
+
+function padLeft(s: string, n: number, pad = ' ') {
+    return pad.repeat(Math.max(0, n - s.length)) + s;
+}
+
+function data2String(data: any): string {
+    if (data instanceof Error) {
+        return data.stack || data.message;
+    }
+    if (data.success === false && data.message) {
+        return data.message;
+    }
+    return data.toString();
 }


### PR DESCRIPTION
Enables nicely formatted log messages with tsserver communication delivered through the LSP messages (so visible in editor's log of LSP communication).