### PR TITLE
feat!: add `tsserver.logDirectory` to initializationOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ typescript-language-server --stdio
     -V, --version                          output the version number
     --stdio                                use stdio (required option)
     --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `3`.
-    --tsserver-log-file <tsServerLogFile>  Specify a tsserver log file. example: --tsserver-log-file=ts-logs.txt
     --tsserver-log-verbosity <verbosity>   Specify tsserver log verbosity (off, terse, normal, verbose). Defaults to `normal`. example: --tsserver-log-verbosity=verbose
     --tsserver-path <path>                 Specify path to tsserver directory. example: --tsserver-path=/Users/me/typescript/lib/
     -h, --help                             output usage information
@@ -89,6 +88,14 @@ The `tsserver` setting specifies additional options related to the internal `tss
 
 ```ts
 interface TsserverOptions {
+    /**
+     * The path to the directory where the `tsserver` logs will be created.
+     * If not provided, the log files will be created within the workspace, inside the `.log` directory.
+     * If not workspace path is provided when initializating the server and no custom path is specified then
+     * the logs will not be created.
+     * @default undefined
+     */
+    logDirectory?: string;
     /**
      * The verbosity of logging of the tsserver communication.
      * Delivered through the LSP messages and not related to file logging.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ interface TsserverOptions {
     /**
      * The path to the directory where the `tsserver` logs will be created.
      * If not provided, the log files will be created within the workspace, inside the `.log` directory.
-     * If not workspace path is provided when initializating the server and no custom path is specified then
+     * If no workspace root is provided when initializating the server and no custom path is specified then
      * the logs will not be created.
      * @default undefined
      */

--- a/src/lsp-connection.ts
+++ b/src/lsp-connection.ts
@@ -11,11 +11,11 @@ import * as lspinlayHints from './lsp-protocol.inlayHints.proposed.js';
 import { LspClientLogger } from './utils/logger.js';
 import { LspServer } from './lsp-server.js';
 import { LspClientImpl } from './lsp-client.js';
+import type { TsServerLogLevel } from './utils/configuration.js';
 
 export interface LspConnectionOptions {
     tsserverPath: string;
-    tsserverLogFile?: string;
-    tsserverLogVerbosity?: string;
+    tsserverLogVerbosity: TsServerLogLevel;
     showMessageLevel: lsp.MessageType;
 }
 
@@ -27,7 +27,6 @@ export function createLspConnection(options: LspConnectionOptions): lsp.Connecti
         logger,
         lspClient,
         tsserverPath: options.tsserverPath,
-        tsserverLogFile: options.tsserverLogFile,
         tsserverLogVerbosity: options.tsserverLogVerbosity,
     });
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -18,7 +18,7 @@ import { LspClient, WithProgressOptions } from './lsp-client.js';
 import { LspServer } from './lsp-server.js';
 import { ConsoleLogger } from './utils/logger.js';
 import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
-import { TypeScriptServiceConfiguration } from './utils/configuration.js';
+import { TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration.js';
 
 const CONSOLE_LOG_LEVEL = ConsoleLogger.toMessageTypeLevel(process.env.CONSOLE_LOG_LEVEL);
 export const PACKAGE_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -171,14 +171,13 @@ export async function createServer(options: TestLspServerOptions): Promise<TestL
     const serverOptions: TypeScriptServiceConfiguration = {
         logger,
         lspClient,
+        tsserverLogVerbosity: TsServerLogLevel.Off,
     };
     const typescriptVersionProvider = new TypeScriptVersionProvider(serverOptions);
     const bundled = typescriptVersionProvider.bundledVersion();
     const server = new TestLspServer({
         ...serverOptions,
         tsserverPath: bundled!.tsServerPath,
-        tsserverLogVerbosity: options.tsserverLogVerbosity,
-        tsserverLogFile: path.resolve(PACKAGE_ROOT, 'tsserver.log'),
     });
 
     lspClient.addApplyWorkspaceEditListener(args => {

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -8,7 +8,7 @@
 /**
  * **IMPORTANT** this module should not depend on `vscode-languageserver` only protocol and types
  */
-import * as lsp from 'vscode-languageserver-protocol';
+import lsp from 'vscode-languageserver-protocol';
 import type tsp from 'typescript/lib/protocol.d.js';
 import type { TraceValue } from './tsServer/tracer.js';
 
@@ -43,7 +43,6 @@ export interface TypeScriptInitializationOptions {
     disableAutomaticTypingAcquisition?: boolean;
     hostInfo?: string;
     locale?: string;
-    logVerbosity?: string;
     maxTsServerMemory?: number;
     npmLocation?: string;
     plugins: TypeScriptPlugin[];
@@ -52,6 +51,14 @@ export interface TypeScriptInitializationOptions {
 }
 
 interface TsserverOptions {
+    /**
+     * The path to the directory where the `tsserver` logs will be created.
+     * If not provided, the log files will be created within the workspace, inside the `.log` directory.
+     * If not workspace path is provided when initializating the server and no custom path is specified then
+     * the logs will not be created.
+     * @default undefined
+     */
+    logDirectory?: string;
     /**
      * The verbosity of logging the tsserver communication through the LSP messages.
      * This doesn't affect the file logging.
@@ -63,7 +70,3 @@ interface TsserverOptions {
 export type TypeScriptInitializeParams = lsp.InitializeParams & {
     initializationOptions?: Partial<TypeScriptInitializationOptions>;
 };
-
-export interface TypeScriptInitializeResult extends lsp.InitializeResult {
-    logFileUri?: string;
-}

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -54,7 +54,7 @@ interface TsserverOptions {
     /**
      * The path to the directory where the `tsserver` logs will be created.
      * If not provided, the log files will be created within the workspace, inside the `.log` directory.
-     * If not workspace path is provided when initializating the server and no custom path is specified then
+     * If no workspace root is provided when initializating the server and no custom path is specified then
      * the logs will not be created.
      * @default undefined
      */

--- a/src/tsServer/logDirectoryProvider.ts
+++ b/src/tsServer/logDirectoryProvider.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface ILogDirectoryProvider {
+    getNewLogDirectory(): string | undefined;
+}
+
+export class LogDirectoryProvider implements ILogDirectoryProvider {
+    public constructor(
+        private readonly rootPath?: string,
+    ) { }
+
+    public getNewLogDirectory(): string | undefined {
+        const root = this.logDirectory();
+        if (root) {
+            try {
+                return fs.mkdtempSync(path.join(root, 'tsserver-log-'));
+            } catch (e) {
+                return undefined;
+            }
+        }
+        return undefined;
+    }
+
+    private logDirectory(): string | undefined {
+        if (!this.rootPath) {
+            return undefined;
+        }
+        try {
+            if (!fs.existsSync(this.rootPath)) {
+                fs.mkdirSync(this.rootPath);
+            }
+            return this.rootPath;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+export const noopLogDirectoryProvider = new class implements ILogDirectoryProvider {
+    public getNewLogDirectory(): undefined {
+        return undefined;
+    }
+};

--- a/src/tsp-client.spec.ts
+++ b/src/tsp-client.spec.ts
@@ -12,7 +12,8 @@ import { filePath, readContents, TestLspClient, uri } from './test-utils.js';
 import { CommandTypes } from './tsp-command-types.js';
 import { Trace } from './tsServer/tracer.js';
 import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
-import { TypeScriptServiceConfiguration } from './utils/configuration.js';
+import { TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration.js';
+import { noopLogDirectoryProvider } from './tsServer/logDirectoryProvider.js';
 
 const assert = chai.assert;
 const logger = new ConsoleLogger();
@@ -24,6 +25,7 @@ const lspClient = new TestLspClient(lspClientOptions, logger);
 const configuration: TypeScriptServiceConfiguration = {
     logger,
     lspClient,
+    tsserverLogVerbosity: TsServerLogLevel.Off,
 };
 const typescriptVersionProvider = new TypeScriptVersionProvider(configuration);
 const bundled = typescriptVersionProvider.bundledVersion();
@@ -32,6 +34,8 @@ let server: TspClient;
 before(() => {
     server = new TspClient({
         ...configuration,
+        logDirectoryProvider: noopLogDirectoryProvider,
+        logVerbosity: configuration.tsserverLogVerbosity,
         trace: Trace.Off,
         typescriptVersion: bundled!,
     });

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -4,13 +4,52 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
+
+/* eslint-disable @typescript-eslint/no-unnecessary-qualifier */
+
 import type { Logger } from '../utils/logger.js';
 import type { LspClient } from '../lsp-client.js';
+
+export enum TsServerLogLevel {
+    Off,
+    Normal,
+    Terse,
+    Verbose,
+}
+
+export namespace TsServerLogLevel {
+    export function fromString(value: string): TsServerLogLevel {
+        switch (value?.toLowerCase()) {
+            case 'normal':
+                return TsServerLogLevel.Normal;
+            case 'terse':
+                return TsServerLogLevel.Terse;
+            case 'verbose':
+                return TsServerLogLevel.Verbose;
+            case 'off':
+            default:
+                return TsServerLogLevel.Off;
+        }
+    }
+
+    export function toString(value: TsServerLogLevel): string {
+        switch (value) {
+            case TsServerLogLevel.Normal:
+                return 'normal';
+            case TsServerLogLevel.Terse:
+                return 'terse';
+            case TsServerLogLevel.Verbose:
+                return 'verbose';
+            case TsServerLogLevel.Off:
+            default:
+                return 'off';
+        }
+    }
+}
 
 export interface TypeScriptServiceConfiguration {
     readonly logger: Logger;
     readonly lspClient: LspClient;
-    readonly tsserverLogFile?: string;
-    readonly tsserverLogVerbosity?: string;
+    readonly tsserverLogVerbosity: TsServerLogLevel;
     readonly tsserverPath?: string;
 }


### PR DESCRIPTION
BREAKING CHANGE: Replace the CLI argument `--tsserver-log-file` with `tsserver.logDirectory` option provided through `initializationOptions` of the `initialize` request.