### PR TITLE
refactor: logger implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ yarn
  - `yarn test` - run all tests
  - `yarn test:watch` - run all tests and enable watch mode for developing
 
-By default only console logs of level `warn` and higher are printed to the console. You can override the `CONSOLE_LOG_LEVEL` level in `package.json` to either `log`, `info`, `warn` or `error` to log other levels.
+By default only console logs of level `warning` and higher are printed to the console. You can override the `CONSOLE_LOG_LEVEL` level in `package.json` to either `log`, `info`, `warning` or `error` to log other levels.
 
 ### Watch
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "clean": "rimraf lib *.tsbuildinfo",
-    "test": "cross-env CONSOLE_LOG_LEVEL=warn TS_NODE_PROJECT=./tsconfig.json mocha",
-    "test:watch": "cross-env CONSOLE_LOG_LEVEL=warn TS_NODE_PROJECT=./tsconfig.json mocha --watch",
-    "test:compiled": "cross-env CONSOLE_LOG_LEVEL=warn mocha \"./lib/**/*.spec.js\"",
+    "test": "cross-env CONSOLE_LOG_LEVEL=warning TS_NODE_PROJECT=./tsconfig.json mocha",
+    "test:watch": "cross-env CONSOLE_LOG_LEVEL=warning TS_NODE_PROJECT=./tsconfig.json mocha --watch",
+    "test:compiled": "cross-env CONSOLE_LOG_LEVEL=warning mocha \"./lib/**/*.spec.js\"",
     "lint": "eslint --ext \".js,.ts\" src",
     "fix": "eslint --ext \".js,.ts\" --fix src",
     "build": "concurrently -n compile,lint -c blue,green \"yarn compile\" \"yarn lint\"",

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -15,7 +15,7 @@ import * as lspsemanticTokens from './semantic-tokens.js';
 import tsp from 'typescript/lib/protocol.d.js';
 import API from './utils/api.js';
 import { CommandTypes, EventTypes } from './tsp-command-types.js';
-import { Logger, PrefixingLogger } from './utils/logger.js';
+import { Logger, LogLevel, PrefixingLogger } from './utils/logger.js';
 import { TspClient } from './tsp-client.js';
 import { DiagnosticEventQueue } from './diagnostic-queue.js';
 import { toDocumentHighlight, asTagsDocumentation, uriToPath, toSymbolKind, toLocation, pathToUri, toTextEdit, asPlainText, normalizePath } from './protocol-translation.js';
@@ -85,7 +85,7 @@ export class LspServer {
             if (userSettingVersion.isValid) {
                 return userSettingVersion;
             }
-            this.logger.warn(`Typescript specified through --tsserver-path ignored due to invalid path "${userSettingVersion.path}"`);
+            this.logger.logIgnoringVerbosity(LogLevel.Warning, `Typescript specified through --tsserver-path ignored due to invalid path "${userSettingVersion.path}"`);
         }
         // Workspace version.
         if (this.workspaceRoot) {
@@ -126,7 +126,7 @@ export class LspServer {
 
         const typescriptVersion = this.findTypescriptVersion();
         if (typescriptVersion) {
-            this.logger.info(`Using Typescript version (${typescriptVersion.source}) ${typescriptVersion.versionString} from path "${typescriptVersion.tsServerPath}"`);
+            this.logger.logIgnoringVerbosity(LogLevel.Info, `Using Typescript version (${typescriptVersion.source}) ${typescriptVersion.versionString} from path "${typescriptVersion.tsServerPath}"`);
         } else {
             throw Error('Could not find a valid TypeScript installation. Please ensure that the "typescript" dependency is installed in the workspace or that a valid --tsserver-path is specified. Exiting.');
         }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -16,11 +16,11 @@ import { normalizePath, pathToUri } from './protocol-translation.js';
 import { TypeScriptInitializationOptions } from './ts-protocol.js';
 import { LspClient, WithProgressOptions } from './lsp-client.js';
 import { LspServer } from './lsp-server.js';
-import { ConsoleLogger } from './utils/logger.js';
+import { ConsoleLogger, LogLevel } from './utils/logger.js';
 import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
 import { TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration.js';
 
-const CONSOLE_LOG_LEVEL = ConsoleLogger.toMessageTypeLevel(process.env.CONSOLE_LOG_LEVEL);
+const CONSOLE_LOG_LEVEL = LogLevel.fromString(process.env.CONSOLE_LOG_LEVEL);
 export const PACKAGE_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const DEFAULT_TEST_CLIENT_CAPABILITIES: lsp.ClientCapabilities = {
@@ -110,7 +110,10 @@ export function toPlatformEOL(text: string): string {
 export class TestLspClient implements LspClient {
     private workspaceEditsListener: ((args: lsp.ApplyWorkspaceEditParams) => void) | null = null;
 
-    constructor(protected options: TestLspServerOptions, protected logger: ConsoleLogger) {}
+    constructor(
+        protected options: TestLspServerOptions,
+        protected logger: ConsoleLogger,
+    ) {}
 
     async createProgressReporter(_token?: lsp.CancellationToken, _workDoneProgress?: lsp.WorkDoneProgressReporter): Promise<lsp.WorkDoneProgressReporter> {
         const reporter = new class implements lsp.WorkDoneProgressReporter {
@@ -173,7 +176,7 @@ export async function createServer(options: TestLspServerOptions): Promise<TestL
         lspClient,
         tsserverLogVerbosity: TsServerLogLevel.Off,
     };
-    const typescriptVersionProvider = new TypeScriptVersionProvider(serverOptions);
+    const typescriptVersionProvider = new TypeScriptVersionProvider(serverOptions, logger);
     const bundled = typescriptVersionProvider.bundledVersion();
     const server = new TestLspServer({
         ...serverOptions,

--- a/src/tsServer/spawner.ts
+++ b/src/tsServer/spawner.ts
@@ -12,7 +12,7 @@
 import path from 'node:path';
 import API from '../utils/api.js';
 import { ServerType } from './requests.js';
-import { Logger } from '../utils/logger.js';
+import { Logger, LogLevel } from '../utils/logger.js';
 import type { TspClientOptions } from '../tsp-client.js';
 import { nodeRequestCancellerFactory } from './cancellation.js';
 import type { ILogDirectoryProvider } from './logDirectoryProvider.js';
@@ -41,9 +41,9 @@ export class TypeScriptServerSpawner {
 
         if (this.isLoggingEnabled(configuration)) {
             if (tsServerLogFile) {
-                this._logger.info(`<${kind}> Log file: ${tsServerLogFile}`);
+                this._logger.logIgnoringVerbosity(LogLevel.Info, `<${kind}> Log file: ${tsServerLogFile}`);
             } else {
-                this._logger.error(`<${kind}> Could not create log directory`);
+                this._logger.logIgnoringVerbosity(LogLevel.Error, `<${kind}> Could not create log directory`);
             }
         }
 

--- a/src/tsp-client.spec.ts
+++ b/src/tsp-client.spec.ts
@@ -27,7 +27,7 @@ const configuration: TypeScriptServiceConfiguration = {
     lspClient,
     tsserverLogVerbosity: TsServerLogLevel.Off,
 };
-const typescriptVersionProvider = new TypeScriptVersionProvider(configuration);
+const typescriptVersionProvider = new TypeScriptVersionProvider(configuration, logger);
 const bundled = typescriptVersionProvider.bundledVersion();
 let server: TspClient;
 


### PR DESCRIPTION
A small refactoring of the logger. Mainly to be able to log certain messages like:

```
        if (this.isLoggingEnabled(configuration)) {
            if (tsServerLogFile) {
                this._logger.logIgnoringVerbosity(LogLevel.Info, `<${kind}> Log file: ${tsServerLogFile}`);
            } else {
                this._logger.logIgnoringVerbosity(LogLevel.Error, `<${kind}> Could not create log directory`);
            }
        }
```

regardless of what the logging level is set to.

Using new `logIgnoringVerbosity` method for that.