### PR TITLE
fix: wrong import completion when insert/replace supported

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -50,11 +50,11 @@ export function asCompletionItem(entry: tsp.CompletionEntry, optionalReplacement
         item.sortText = '\uffff' + entry.sortText;
     }
 
-    const { isSnippet, sourceDisplay } = entry;
+    const { isSnippet, replacementSpan, sourceDisplay } = entry;
     if (isSnippet && !features.completionSnippets) {
         return null;
     }
-    if (features.completionSnippets && (isSnippet || entry.isImportStatementCompletion || item.kind === lsp.CompletionItemKind.Function || item.kind === lsp.CompletionItemKind.Method)) {
+    if (features.completionSnippets && (isSnippet || item.kind === lsp.CompletionItemKind.Function || item.kind === lsp.CompletionItemKind.Method)) {
         // Import statements, Functions and Methods can result in a snippet completion when resolved.
         item.insertTextFormat = lsp.InsertTextFormat.Snippet;
     }
@@ -62,15 +62,17 @@ export function asCompletionItem(entry: tsp.CompletionEntry, optionalReplacement
         item.detail = asPlainText(sourceDisplay);
     }
 
-    let insertText = entry.insertText;
-    const replacementSpan = entry.replacementSpan || (features.completionInsertReplaceSupport ? optionalReplacementSpan : undefined);
-    let replacementRange = replacementSpan && Range.fromTextSpan(replacementSpan);
-    // Make sure we only replace a single line at most
-    if (replacementRange && replacementRange.start.line !== replacementRange.end.line) {
-        replacementRange = lsp.Range.create(replacementRange.start, document.getLineEnd(replacementRange.start.line));
-    }
-    if (insertText && replacementRange && insertText[0] === '[') { // o.x -> o['x']
+    let { insertText } = entry;
+    if (insertText && replacementSpan && insertText[0] === '[') { // o.x -> o['x']
         item.filterText = '.' + item.label;
+    }
+    const range = getRangeFromReplacementSpan(replacementSpan, optionalReplacementSpan, position, document, features);
+    if (range) {
+        item.textEdit = range.insert
+            ? lsp.InsertReplaceEdit.create(insertText || item.label, range.insert, range.replace)
+            : lsp.TextEdit.replace(range.replace, insertText || item.label);
+    } else {
+        item.insertText = insertText;
     }
     if (entry.kindModifiers) {
         const kindModifiers = new Set(entry.kindModifiers.split(/,|\s+/g));
@@ -105,20 +107,31 @@ export function asCompletionItem(entry: tsp.CompletionEntry, optionalReplacement
             }
         }
     }
-    if (replacementRange) {
-        if (!insertText) {
-            insertText = item.label;
-        }
-        if (features.completionInsertReplaceSupport) {
-            const insertRange = lsp.Range.create(replacementRange.start, position);
-            item.textEdit = lsp.InsertReplaceEdit.create(insertText, insertRange, replacementRange);
-        } else {
-            item.textEdit = lsp.TextEdit.replace(replacementRange, insertText);
-        }
-    } else {
-        item.insertText = insertText;
-    }
     return item;
+}
+
+function getRangeFromReplacementSpan(
+    replacementSpan: tsp.TextSpan | undefined, optionalReplacementSpan: tsp.TextSpan | undefined, position: lsp.Position, document: LspDocument, features: SupportedFeatures,
+): { insert?: lsp.Range; replace: lsp.Range; } | undefined {
+    if (replacementSpan) {
+        // If TS provides an explicit replacement span with an entry, we should use it and not provide an insert.
+        return {
+            replace: ensureRangeIsOnSingleLine(Range.fromTextSpan(replacementSpan), document),
+        };
+    }
+    if (features.completionInsertReplaceSupport && optionalReplacementSpan) {
+        return {
+            insert: lsp.Range.create(position, position),
+            replace: ensureRangeIsOnSingleLine(Range.fromTextSpan(optionalReplacementSpan), document),
+        };
+    }
+}
+
+function ensureRangeIsOnSingleLine(range: lsp.Range, document: LspDocument): lsp.Range {
+    if (range.start.line !== range.end.line) {
+        return lsp.Range.create(range.start, document.getLineEnd(range.start.line));
+    }
+    return range;
 }
 
 function asCompletionItemKind(kind: ScriptElementKind): lsp.CompletionItemKind {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -120,9 +120,10 @@ function getRangeFromReplacementSpan(
         };
     }
     if (features.completionInsertReplaceSupport && optionalReplacementSpan) {
+        const range = ensureRangeIsOnSingleLine(Range.fromTextSpan(optionalReplacementSpan), document);
         return {
-            insert: lsp.Range.create(position, position),
-            replace: ensureRangeIsOnSingleLine(Range.fromTextSpan(optionalReplacementSpan), document),
+            insert: lsp.Range.create(range.start, position),
+            replace: ensureRangeIsOnSingleLine(range, document),
         };
     }
 }

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -221,8 +221,34 @@ describe('completion', () => {
         assert.isNotNull(proposals);
         const completion = proposals!.items.find(completion => completion.label === 'getById');
         assert.isDefined(completion);
-        assert.isDefined(completion!.textEdit);
-        assert.containsAllKeys(completion!.textEdit, ['newText', 'insert', 'replace']);
+        assert.deepInclude(completion!, {
+            label: 'getById',
+            kind: lsp.CompletionItemKind.Method,
+            insertTextFormat: lsp.InsertTextFormat.Snippet,
+            textEdit: {
+                newText: 'getById',
+                insert: {
+                    start: {
+                        line: 6,
+                        character: 20,
+                    },
+                    end: {
+                        line: 6,
+                        character: 23,
+                    },
+                },
+                replace: {
+                    start: {
+                        line: 6,
+                        character: 20,
+                    },
+                    end: {
+                        line: 6,
+                        character: 27,
+                    },
+                },
+            },
+        });
         server.didCloseTextDocument({ textDocument: doc });
     });
 

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -265,6 +265,40 @@ describe('completion', () => {
         localServer.shutdown();
     });
 
+    it('provides snippet completion in import statement', async () => {
+        const doc = {
+            uri: uri('bar.ts'),
+            languageId: 'typescript',
+            version: 1,
+            text: 'import { readFile }',
+        };
+        server.didOpenTextDocument({ textDocument: doc });
+        const proposals = await server.completion({ textDocument: doc, position: positionAfter(doc, 'readFile') });
+        assert.isNotNull(proposals);
+        const completion = proposals!.items.find(completion => completion.label === 'readFile');
+        assert.isDefined(completion);
+        assert.deepInclude(completion!, {
+            label: 'readFile',
+            kind: lsp.CompletionItemKind.Function,
+            insertTextFormat: lsp.InsertTextFormat.Snippet,
+            detail: 'fs',
+            textEdit: {
+                newText: 'import { readFile$1 } from "fs";',
+                range: {
+                    start: {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: {
+                        line: 0,
+                        character: 19,
+                    },
+                },
+            },
+        });
+        server.didCloseTextDocument({ textDocument: doc });
+    });
+
     it('includes detail field with package name for auto-imports', async () => {
         const doc = {
             uri: uri('bar.ts'),
@@ -415,27 +449,19 @@ describe('completion', () => {
         });
         assert.isNotNull(proposals);
         const completion = proposals!.items.find(completion => completion.label === 'fs/read');
-        assert.strictEqual(completion!.label, 'fs/read');
-        assert.deepStrictEqual(completion!.textEdit, {
-            newText: 'fs/read',
-            insert: {
-                start: {
-                    line: 5,
-                    character: 20,
-                },
-                end: {
-                    line: 5,
-                    character: 23,
-                },
-            },
-            replace: {
-                start: {
-                    line: 5,
-                    character: 20,
-                },
-                end: {
-                    line: 5,
-                    character: 24,
+        assert.deepInclude(completion!, {
+            label: 'fs/read',
+            textEdit: {
+                newText: 'fs/read',
+                range: {
+                    start: {
+                        line: 5,
+                        character: 20,
+                    },
+                    end: {
+                        line: 5,
+                        character: 24,
+                    },
                 },
             },
         });


### PR DESCRIPTION
Fixes regression for clients that have `insertReplaceSupport` where completing:

```ts
import { readFil }
```

would result in incorrect insert:

```ts
import { readFile } from "fs"; }
```

The TextEdit in this case would be:

```
      "textEdit": {
        "insert": {
          "end": {
            "character": 16,
            "line": 0
          },
          "start": {
            "character": 0,
            "line": 0
          }
        },
        "newText": "import { readFile$1 } from \"fs\";",
        "replace": {
          "end": {
            "character": 18,
            "line": 0
          },
          "start": {
            "character": 0,
            "line": 0
          }
        }
      }
```

and the problem would be in the `insert` range.

We should not be providing both insert and replace ranges when TS completion entry has its own `replacementSpan` provided as in that case it's the only valid option.

@predragnikolic 