### PR TITLE
fix(completions): remove filterText override for bracket accessor

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -63,17 +63,6 @@ export function asCompletionItem(entry: tsp.CompletionEntry, optionalReplacement
     }
 
     let { insertText } = entry;
-    if (insertText && replacementSpan && insertText[0] === '[') { // o.x -> o['x']
-        item.filterText = '.' + item.label;
-    }
-    const range = getRangeFromReplacementSpan(replacementSpan, optionalReplacementSpan, position, document, features);
-    if (range) {
-        item.textEdit = range.insert
-            ? lsp.InsertReplaceEdit.create(insertText || item.label, range.insert, range.replace)
-            : lsp.TextEdit.replace(range.replace, insertText || item.label);
-    } else {
-        item.insertText = insertText;
-    }
     if (entry.kindModifiers) {
         const kindModifiers = new Set(entry.kindModifiers.split(/,|\s+/g));
         if (kindModifiers.has(KindModifiers.optional)) {
@@ -106,6 +95,14 @@ export function asCompletionItem(entry: tsp.CompletionEntry, optionalReplacement
                 }
             }
         }
+    }
+    const range = getRangeFromReplacementSpan(replacementSpan, optionalReplacementSpan, position, document, features);
+    if (range) {
+        item.textEdit = range.insert
+            ? lsp.InsertReplaceEdit.create(insertText || item.label, range.insert, range.replace)
+            : lsp.TextEdit.replace(range.replace, insertText || item.label);
+    } else {
+        item.insertText = insertText;
     }
     return item;
 }


### PR DESCRIPTION
Removed this old code that overridden filterText for bracket accessor completions.

This old code originally came from VSCode and was later replaced there with a quite different code: https://github.com/microsoft/vscode/commit/beb5998ea3d6b4cae43b3a09ecdf11e3bd692667 to fix issue https://github.com/microsoft/vscode/issues/63100

I've tested in ST and don't see the issue that VSCode had so given no evidence that it's needed outside of VSCode, I'm not trying to replicate what they did here.

Also, in ST at least, the results are better without this old code:

Before:

<img width="274" alt="Screenshot 2022-09-26 at 13 01 25" src="https://user-images.githubusercontent.com/153197/192262391-51cb02f3-4a87-499d-8357-95129dd9872b.png">

After:

<img width="266" alt="Screenshot 2022-09-26 at 13 01 06" src="https://user-images.githubusercontent.com/153197/192262411-edfa733a-977b-46bb-858d-9c00d078b2ea.png">

So before this change editor has shown a leading dot which is not really needed or expected.

As a bonus (in ST at least) it makes this case better as we can see that the property is optional:

<img width="278" alt="Screenshot 2022-09-26 at 13 13 14" src="https://user-images.githubusercontent.com/153197/192262567-8b661c57-b69f-4416-9684-baff7ffe0023.png">
