### PR TITLE
fix(completions): don't create snippet kind without `completeFunctionCalls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,11 @@ Some of the preferences can be controlled through the `workspace/didChangeConfig
 [language].inlayHints.includeInlayVariableTypeHintsWhenTypeMatchesName: boolean;
 /**
  * Complete functions with their parameter signature.
+ *
+ * This functionality relies on LSP client resolving the completion using the `completionItem/resolve` call. If the
+ * client can't do that before inserting the completion then it's not safe to enable it as it will result in some
+ * completions having a snippet type without actually being snippets, which can then cause problems when inserting them.
+ *
  * @default false
  */
 completions.completeFunctionCalls: boolean;

--- a/src/configuration-manager.ts
+++ b/src/configuration-manager.ts
@@ -88,7 +88,7 @@ export class ConfigurationManager {
     }
 
     public setWorkspaceConfiguration(configuration: WorkspaceConfiguration): void {
-        this.workspaceConfiguration = configuration;
+        this.workspaceConfiguration = deepmerge({}, configuration);
     }
 
     public async setAndConfigureTspClient(workspaceFolder: string | undefined, client: TspClient, hostInfo?: TypeScriptInitializationOptions['hostInfo']): Promise<void> {

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -8,10 +8,11 @@
 import * as chai from 'chai';
 import fs from 'fs-extra';
 import * as lsp from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as lspcalls from './lsp-protocol.calls.proposed.js';
 import { uri, createServer, position, lastPosition, filePath, positionAfter, readContents, TestLspServer, toPlatformEOL } from './test-utils.js';
-import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Commands } from './commands.js';
+import { SemicolonPreference } from './ts-protocol.js';
 import { CodeActionKind } from './utils/types.js';
 
 const assert = chai.assert;
@@ -370,7 +371,7 @@ describe('completion', () => {
         server.updateWorkspaceSettings({
             typescript: {
                 format: {
-                    semicolons: 'remove',
+                    semicolons: SemicolonPreference.Remove,
                     insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false,
                 },
             },
@@ -407,7 +408,7 @@ describe('completion', () => {
         server.updateWorkspaceSettings({
             typescript: {
                 format: {
-                    semicolons: 'ignore',
+                    semicolons: SemicolonPreference.Ignore,
                     insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
                 },
             },

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -583,6 +583,8 @@ export class LspServer {
             throw new Error('The document should be opened for completion, file: ' + file);
         }
 
+        const completionOptions = this.configurationManager.workspaceConfiguration.completions || {};
+
         try {
             const result = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionInfo, {
                 file,
@@ -601,7 +603,7 @@ export class LspServer {
                 if (entry.kind === 'warning') {
                     continue;
                 }
-                const completion = asCompletionItem(entry, optionalReplacementSpan, file, params.position, document, this.features);
+                const completion = asCompletionItem(entry, optionalReplacementSpan, file, params.position, document, completionOptions, this.features);
                 if (!completion) {
                     continue;
                 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -66,6 +66,12 @@ const DEFAULT_TEST_CLIENT_INITIALIZATION_OPTIONS: TypeScriptInitializationOption
     },
 };
 
+const DEFAULT_WORKSPACE_SETTINGS: lsp.LSPAny = {
+    completions: {
+        completeFunctionCalls: true,
+    },
+};
+
 export function uri(...components: string[]): string {
     const resolved = filePath(...components);
     return pathToUri(resolved, undefined);
@@ -159,6 +165,13 @@ export class TestLspClient implements LspClient {
 
 export class TestLspServer extends LspServer {
     workspaceEdits: lsp.ApplyWorkspaceEditParams[] = [];
+
+    updateWorkspaceSettings(settings: lsp.LSPAny): void {
+        const configuration: lsp.DidChangeConfigurationParams = {
+            settings: deepmerge(DEFAULT_WORKSPACE_SETTINGS, settings),
+        };
+        this.didChangeConfiguration(configuration);
+    }
 }
 
 interface TestLspServerOptions {
@@ -195,5 +208,6 @@ export async function createServer(options: TestLspServerOptions): Promise<TestL
         initializationOptions: DEFAULT_TEST_CLIENT_INITIALIZATION_OPTIONS,
         workspaceFolders: null,
     });
+    server.updateWorkspaceSettings({});
     return server;
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import deepmerge from 'deepmerge';
 import * as lsp from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { WorkspaceConfiguration } from './configuration-manager.js';
 import { normalizePath, pathToUri } from './protocol-translation.js';
 import { TypeScriptInitializationOptions } from './ts-protocol.js';
 import { LspClient, WithProgressOptions } from './lsp-client.js';
@@ -66,7 +67,7 @@ const DEFAULT_TEST_CLIENT_INITIALIZATION_OPTIONS: TypeScriptInitializationOption
     },
 };
 
-const DEFAULT_WORKSPACE_SETTINGS: lsp.LSPAny = {
+const DEFAULT_WORKSPACE_SETTINGS: WorkspaceConfiguration = {
     completions: {
         completeFunctionCalls: true,
     },
@@ -166,7 +167,7 @@ export class TestLspClient implements LspClient {
 export class TestLspServer extends LspServer {
     workspaceEdits: lsp.ApplyWorkspaceEditParams[] = [];
 
-    updateWorkspaceSettings(settings: lsp.LSPAny): void {
+    updateWorkspaceSettings(settings: WorkspaceConfiguration): void {
         const configuration: lsp.DidChangeConfigurationParams = {
             settings: deepmerge(DEFAULT_WORKSPACE_SETTINGS, settings),
         };

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -67,11 +67,7 @@ const DEFAULT_TEST_CLIENT_INITIALIZATION_OPTIONS: TypeScriptInitializationOption
     },
 };
 
-const DEFAULT_WORKSPACE_SETTINGS: WorkspaceConfiguration = {
-    completions: {
-        completeFunctionCalls: true,
-    },
-};
+const DEFAULT_WORKSPACE_SETTINGS: WorkspaceConfiguration = {};
 
 export function uri(...components: string[]): string {
     const resolved = filePath(...components);

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -25,6 +25,12 @@ export class DisplayPartKind {
     public static readonly text = 'text';
 }
 
+export enum SemicolonPreference {
+    Ignore = 'ignore',
+    Insert = 'insert',
+    Remove = 'remove'
+}
+
 export interface SupportedFeatures {
     codeActionDisabledSupport?: boolean;
     completionInsertReplaceSupport?: boolean;


### PR DESCRIPTION
Server was supposed to create snippet completions on "resolve" for `method` and `function` completion kinds when the `completeFunctionCalls` workspace settings was enabled.

The code that has created the snippet during "resolve" was checking before-mentioned option but the code that initially set the `insertTextFormat` to `Snippet` did not. That meant that with `completeFunctionCalls` disabled, the `method` and `function` completions were set to `Snippet` kind initially but without a chance of being changed to actual snippets during "resolve".

And for editors that can't use resolved values that meant that those would potentially receive completions with unescaped `$` character in them while not actually being actual snippet.