### PR TITLE
fix: disable IPC communication until TypeScript bug is fixed

### DIFF
--- a/src/tsServer/serverProcess.ts
+++ b/src/tsServer/serverProcess.ts
@@ -15,7 +15,7 @@ import type { Readable } from 'node:stream';
 import type tsp from 'typescript/lib/protocol.d.js';
 import { TsServerProcess, TsServerProcessFactory, TsServerProcessKind } from './server.js';
 import type { TspClientOptions } from '../tsp-client.js';
-import API from '../utils/api.js';
+// import API from '../utils/api.js';
 import type { TypeScriptVersion } from './versionProvider.js';
 
 export class NodeTsServerProcessFactory implements TsServerProcessFactory {
@@ -26,7 +26,7 @@ export class NodeTsServerProcessFactory implements TsServerProcessFactory {
         configuration: TspClientOptions,
     ): TsServerProcess {
         const tsServerPath = version.tsServerPath;
-        const useIpc = version.version?.gte(API.v460);
+        const useIpc = false;  // version.version?.gte(API.v460);
 
         const runtimeArgs = [...args];
         if (useIpc) {

--- a/src/tsServer/spawner.ts
+++ b/src/tsServer/spawner.ts
@@ -47,12 +47,12 @@ export class TypeScriptServerSpawner {
             }
         }
 
-        const process = processFactory.fork(version, args, TsServerProcessKind.Main, configuration);
+        const tsProcess = processFactory.fork(version, args, TsServerProcessKind.Main, configuration);
         this._logger.log('Starting tsserver');
         return new ProcessBasedTsServer(
             kind,
             this.kindToServerType(kind),
-            process,
+            tsProcess,
             tsServerLogFile,
             canceller,
             version,


### PR DESCRIPTION
The issue with using IPC communication for communicating with `tsserver` is that if the parent process gets killed then the `tsserver` process does not shut itself down.

This will be re-enabled once the Typescript issue (https://github.com/microsoft/TypeScript/issues/51100) is fixed.

Fixes #599