### PR TITLE
feat: add `_typescript.configurePlugin` workspace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,20 @@ Most of the time, you'll execute commands with arguments retrieved from another 
     void
     ```
 
+### Configure plugin
+
+- Request:
+    ```ts
+    {
+        command: `_typescript.configurePlugin`
+        arguments: [pluginName: string, configuration: any]
+    }
+    ```
+- Response:
+    ```ts
+    void
+    ```
+
 ## Inlay hints (`typescript/inlayHints`) (experimental)
 
 > !!! This implementation is deprecated. Use the spec-compliant `textDocument/inlayHint` request instead. !!!

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,6 +11,7 @@ export const Commands = {
     APPLY_WORKSPACE_EDIT: '_typescript.applyWorkspaceEdit',
     APPLY_CODE_ACTION: '_typescript.applyCodeAction',
     APPLY_REFACTORING: '_typescript.applyRefactoring',
+    CONFIGURE_PLUGIN: '_typescript.configurePlugin',
     ORGANIZE_IMPORTS: '_typescript.organizeImports',
     APPLY_RENAME_FILE: '_typescript.applyRenameFile',
     APPLY_COMPLETION_CODE_ACTION: '_typescript.applyCompletionCodeAction',

--- a/src/configuration-manager.ts
+++ b/src/configuration-manager.ts
@@ -116,6 +116,14 @@ export class ConfigurationManager {
         await this.tspClient?.request(CommandTypes.Configure, args);
     }
 
+    public async configurePlugin(pluginName: string, configuration: unknown): Promise<void> {
+        const args: tsp.ConfigurePluginRequestArguments = {
+            configuration,
+            pluginName,
+        };
+        await this.tspClient?.request(CommandTypes.ConfigurePlugin, args);
+    }
+
     public getPreferences(filename: string): tsp.UserPreferences {
         if (this.tspClient?.apiVersion.lt(API.v290)) {
             return {};

--- a/src/configuration-manager.ts
+++ b/src/configuration-manager.ts
@@ -116,14 +116,6 @@ export class ConfigurationManager {
         await this.tspClient?.request(CommandTypes.Configure, args);
     }
 
-    public async configurePlugin(pluginName: string, configuration: unknown): Promise<void> {
-        const args: tsp.ConfigurePluginRequestArguments = {
-            configuration,
-            pluginName,
-        };
-        await this.tspClient?.request(CommandTypes.ConfigurePlugin, args);
-    }
-
     public getPreferences(filename: string): tsp.UserPreferences {
         if (this.tspClient?.apiVersion.lt(API.v290)) {
             return {};

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -917,8 +917,14 @@ export class LspServer {
                 });
             }
         } else if (arg.command === Commands.CONFIGURE_PLUGIN && arg.arguments) {
-            const [pluginName, options] = arg.arguments as [string, unknown];
-            await this.configurationManager.configurePlugin(pluginName, options);
+            const [pluginName, configuration] = arg.arguments as [string, unknown];
+
+            if (this.tspClient?.apiVersion.gte(API.v314)) {
+                this.tspClient.executeWithoutWaitingForResponse(CommandTypes.ConfigurePlugin, {
+                    configuration,
+                    pluginName,
+                });
+            }
         } else if (arg.command === Commands.ORGANIZE_IMPORTS && arg.arguments) {
             const file = arg.arguments[0] as string;
             const additionalArguments: { skipDestructiveCodeActions?: boolean; } = arg.arguments[1] || {};

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -238,6 +238,7 @@ export class LspServer {
                         Commands.APPLY_WORKSPACE_EDIT,
                         Commands.APPLY_CODE_ACTION,
                         Commands.APPLY_REFACTORING,
+                        Commands.CONFIGURE_PLUGIN,
                         Commands.ORGANIZE_IMPORTS,
                         Commands.APPLY_RENAME_FILE,
                         Commands.SOURCE_DEFINITION,
@@ -915,6 +916,9 @@ export class LspServer {
                     position: Position.fromLocation(renameLocation),
                 });
             }
+        } else if (arg.command === Commands.CONFIGURE_PLUGIN && arg.arguments) {
+            const [pluginName, options] = arg.arguments as [string, unknown];
+            await this.configurationManager.configurePlugin(pluginName, options);
         } else if (arg.command === Commands.ORGANIZE_IMPORTS && arg.arguments) {
             const file = arg.arguments[0] as string;
             const additionalArguments: { skipDestructiveCodeActions?: boolean; } = arg.arguments[1] || {};

--- a/src/tsServer/requests.ts
+++ b/src/tsServer/requests.ts
@@ -44,6 +44,7 @@ export interface TypeScriptRequestTypes {
     [CommandTypes.CompletionDetails]: [tsp.CompletionDetailsRequestArgs, tsp.CompletionDetailsResponse];
     [CommandTypes.CompletionInfo]: [tsp.CompletionsRequestArgs, tsp.CompletionInfoResponse];
     [CommandTypes.Configure]: [tsp.ConfigureRequestArguments, tsp.ConfigureResponse];
+    [CommandTypes.ConfigurePlugin]: [tsp.ConfigurePluginRequestArguments, tsp.ConfigurePluginResponse];
     [CommandTypes.Definition]: [tsp.FileLocationRequestArgs, tsp.DefinitionResponse];
     [CommandTypes.DefinitionAndBoundSpan]: [tsp.FileLocationRequestArgs, tsp.DefinitionInfoAndBoundSpanResponse];
     [CommandTypes.DocCommentTemplate]: [tsp.FileLocationRequestArgs, tsp.DocCommandTemplateResponse];


### PR DESCRIPTION
This adds support for the `_typescript.configurePlugin` command which allows clients to dynamically update plugin configuration.  This is useful when configuring global plugins which, since defined via the command line flags, cannot be configured the same way they might when defined in a local `tsconfig.json` file.

An example of this in Neovim which enables the `typescript-styled-plugin` with some configuration changes.

```lua
require("lspconfig").tsserver.setup({
  init_options = {
    plugins = {
      {
        name = "typescript-styled-plugin",
        location = "..."
      }
    }
  },
  on_init = function()
    local params = {
      command = "_typescript.configurePlugin",
      arguments = {
        "typescript-styled-plugin",
        {
          validate = false,
          emmet = {
            showExpandedAbbreviation = false
          }
        }
      },
    }
    
    client.request("workspace/executeCommand", params)
  end
})
```