### PR TITLE
fix: respect user-provided tsserver.js path from `--tsserver-path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ typescript-language-server --stdio
     -h, --help                             output usage information
 ```
 
-> Note: The path passed to `--tsserver-path` can be a path to the `[...]/typescript/lib/tssserver.js` file or to the `[...]/typescript/lib/` directory and not to the shell script `[...]/node_modules/.bin/tsserver`. Though for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script.
+> Note: The path passed to `--tsserver-path` should be a path to the `[...]/typescript/lib/tssserver.js` file or to the `[...]/typescript/lib/` directory and not to the shell script `[...]/node_modules/.bin/tsserver`. Though for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script.
 
 ## initializationOptions
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Maintained by a [community of contributors](https://github.com/typescript-langua
     - [Apply Refactoring](#apply-refactoring)
     - [Organize Imports](#organize-imports)
     - [Rename File](#rename-file)
+    - [Configure plugin](#configure-plugin)
 - [Inlay hints \(`typescript/inlayHints`\) \(experimental\)](#inlay-hints-typescriptinlayhints-experimental)
 - [Callers and callees \(`textDocument/calls`\) \(experimental\)](#callers-and-callees-textdocumentcalls-experimental)
 - [Supported Protocol features](#supported-protocol-features)
@@ -66,7 +67,7 @@ typescript-language-server --stdio
     -h, --help                             output usage information
 ```
 
-> Note: The path passed to `--tsserver-path` should ideally be a path to the `/.../typescript/lib/` directory and not to the shell script `/.../node_modules/.bin/tsserver` or `tsserver`. Though for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script.
+> Note: The path passed to `--tsserver-path` can be a path to the `[...]/typescript/lib/tssserver.js` file or to the `[...]/typescript/lib/` directory and not to the shell script `[...]/node_modules/.bin/tsserver`. Though for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script.
 
 ## initializationOptions
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ const program = new Command('typescript-language-server')
     .option('--log-level <logLevel>', 'A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.')
     .option('--tsserver-log-verbosity <tsserverLogVerbosity>', 'Specify a tsserver log verbosity (terse, normal, verbose). Defaults to `normal`.' +
       ' example: --tsserver-log-verbosity verbose')
-    .option('--tsserver-path <path>', 'Specify path to tsserver directory. example: --tsserver-path=/Users/me/typescript/lib/')
+    .option('--tsserver-path <path>', 'Specify path to tsserver.js or the lib directory. example: --tsserver-path=/Users/me/typescript/lib/tsserver.js')
     .parse(process.argv);
 
 const options = program.opts();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,9 +19,9 @@ const program = new Command('typescript-language-server')
     .version(version)
     .requiredOption('--stdio', 'use stdio')
     .option('--log-level <logLevel>', 'A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.')
-    .option('--tsserver-log-verbosity <tsserverLogVerbosity>', 'Specify a tsserver log verbosity (terse, normal, verbose). Defaults to `normal`.' +
+    .option('--tsserver-log-verbosity <tsserverLogVerbosity>', '[deprecated] Specify a tsserver log verbosity (terse, normal, verbose). Defaults to `normal`.' +
       ' example: --tsserver-log-verbosity verbose')
-    .option('--tsserver-path <path>', 'Specify path to tsserver.js or the lib directory. example: --tsserver-path=/Users/me/typescript/lib/tsserver.js')
+    .option('--tsserver-path <path>', '[deprecated] Specify path to tsserver.js or the lib directory. example: --tsserver-path=/Users/me/typescript/lib/tsserver.js')
     .parse(process.argv);
 
 const options = program.opts();


### PR DESCRIPTION
Previous logic disallowed one to pass full path to an existing tsserver.js like for example a locally built one at `../built/local/tsserver.js`.