### PR TITLE
Prevent exception when tsserver crashes

### DIFF
--- a/src/tsServer/serverProcess.ts
+++ b/src/tsServer/serverProcess.ts
@@ -147,7 +147,7 @@ class StdioChildServerProcess implements TsServerProcess {
 
     kill(): void {
         this._process.kill();
-        this.reader.dispose();
+        this.reader?.dispose();
         this._reader = null;
     }
 }


### PR DESCRIPTION
I was debugging an issue where tsserver crashes, and noticed the langserver also crashes because of a null dereference here. The exact scenario is a bit difficult to reproduce, because I'm debugging an issue in the patch Yarn v3 applies to TypeScript, and involves a very specific setup where langserver is a global install using PnP, but TypeScript is project local install using node_modules.

It was also a bit difficult to surface the exception in tsserver. I tried modifying the subprocess `stdio` config to inherit stderr (which I think is something we should probably do any way?), but it didn't seem to help. (I'm using neovim, and was hoping to see the exception in  `:LspLog` perhaps, but it only shows the 'exit code 1' message.)