### PR TITLE
fix(completions): don't insert call snippet if already a call

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -235,14 +235,13 @@ export async function asResolvedCompletionItem(
         item.additionalTextEdits = asAdditionalTextEdits(details.codeActions, filepath);
         item.command = asCommand(details.codeActions, item.data.file);
     }
-    if (document) {
-        if (features.completionSnippets && canCreateSnippetOfFunctionCall(item.kind, options)) {
-            const { line, offset } = item.data;
-            const position = Position.fromLocation({ line, offset });
-            const shouldCompleteFunction = await isValidFunctionCompletionContext(filepath, position, client, document);
-            if (shouldCompleteFunction) {
-                createSnippetOfFunctionCall(item, details);
-            }
+
+    if (document && features.completionSnippets && canCreateSnippetOfFunctionCall(item.kind, options)) {
+        const { line, offset } = item.data;
+        const position = Position.fromLocation({ line, offset });
+        const shouldCompleteFunction = await isValidFunctionCompletionContext(filepath, position, client, document);
+        if (shouldCompleteFunction) {
+            createSnippetOfFunctionCall(item, details);
         }
     }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -221,6 +221,7 @@ function asCommitCharacters(kind: ScriptElementKind): string[] | undefined {
 export async function asResolvedCompletionItem(
     item: lsp.CompletionItem,
     details: tsp.CompletionEntryDetails,
+    document: LspDocument | undefined,
     client: TspClient,
     filePathConverter: IFilePathToResourceConverter,
     options: WorkspaceConfigurationCompletionOptions,
@@ -234,41 +235,43 @@ export async function asResolvedCompletionItem(
         item.additionalTextEdits = asAdditionalTextEdits(details.codeActions, filepath);
         item.command = asCommand(details.codeActions, item.data.file);
     }
-    if (features.completionSnippets && canCreateSnippetOfFunctionCall(item.kind, options)) {
-        const { line, offset } = item.data;
-        const position = Position.fromLocation({ line, offset });
-        const shouldCompleteFunction = await isValidFunctionCompletionContext(filepath, position, client);
-        if (shouldCompleteFunction) {
-            createSnippetOfFunctionCall(item, details);
+    if (document) {
+        if (features.completionSnippets && canCreateSnippetOfFunctionCall(item.kind, options)) {
+            const { line, offset } = item.data;
+            const position = Position.fromLocation({ line, offset });
+            const shouldCompleteFunction = await isValidFunctionCompletionContext(filepath, position, client, document);
+            if (shouldCompleteFunction) {
+                createSnippetOfFunctionCall(item, details);
+            }
         }
     }
 
     return item;
 }
 
-async function isValidFunctionCompletionContext(filepath: string, position: lsp.Position, client: TspClient): Promise<boolean> {
+async function isValidFunctionCompletionContext(filepath: string, position: lsp.Position, client: TspClient, document: LspDocument): Promise<boolean> {
     // Workaround for https://github.com/Microsoft/TypeScript/issues/12677
     // Don't complete function calls inside of destructive assigments or imports
     try {
         const args: tsp.FileLocationRequestArgs = Position.toFileLocationRequestArgs(filepath, position);
         const response = await client.request(tsp.CommandTypes.Quickinfo, args);
-        if (response.type !== 'response') {
-            return true;
-        }
-
-        const { body } = response;
-        switch (body?.kind) {
-            case 'var':
-            case 'let':
-            case 'const':
-            case 'alias':
-                return false;
-            default:
-                return true;
+        if (response.type === 'response' && response.body) {
+            switch (response.body.kind) {
+                case 'var':
+                case 'let':
+                case 'const':
+                case 'alias':
+                    return false;
+            }
         }
     } catch {
-        return true;
+        // Noop
     }
+
+    // Don't complete function call if there is already something that looks like a function call
+    // https://github.com/microsoft/vscode/issues/18131
+    const after = document.getLine(position.line).slice(position.character);
+    return after.match(/^[a-z_$0-9]*\s*\(/gi) === null;
 }
 
 function canCreateSnippetOfFunctionCall(kind: lsp.CompletionItemKind | undefined, options: WorkspaceConfigurationCompletionOptions): boolean {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -632,13 +632,14 @@ export class LspServer {
 
     async completionResolve(item: lsp.CompletionItem): Promise<lsp.CompletionItem> {
         this.logger.log('completion/resolve', item);
+        const document = item.data?.file ? this.documents.get(item.data.file) : undefined;
         await this.configurationManager.configureGloballyFromDocument(item.data.file);
         const { body } = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionDetails, item.data));
         const details = body && body.length && body[0];
         if (!details) {
             return item;
         }
-        return asResolvedCompletionItem(item, details, this.tspClient, this.documents, this.configurationManager.workspaceConfiguration.completions || {}, this.features);
+        return asResolvedCompletionItem(item, details, document, this.tspClient, this.documents, this.configurationManager.workspaceConfiguration.completions || {}, this.features);
     }
 
     async hover(params: lsp.TextDocumentPositionParams): Promise<lsp.Hover> {


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/18131

Align with the implementation of vscode:

https://github.com/microsoft/vscode/blob/6215269681d1afe10ddd786567d9753847213229/extensions/typescript-language-features/src/languageFeatures/completions.ts#L280-L299