### PR TITLE
fix: remove hard dependency on typescript

### DIFF
--- a/src/configuration-manager.ts
+++ b/src/configuration-manager.ts
@@ -2,11 +2,12 @@ import deepmerge from 'deepmerge';
 import path from 'node:path';
 import type * as lsp from 'vscode-languageserver';
 import { LspDocuments } from './document.js';
-import { tsp, TypeScriptInitializationOptions } from './ts-protocol.js';
+import { CommandTypes, ModuleKind, ScriptTarget, TypeScriptInitializationOptions } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import type { TspClient } from './tsp-client.js';
 import API from './utils/api.js';
 
-const DEFAULT_TSSERVER_PREFERENCES: Required<tsp.UserPreferences> = {
+const DEFAULT_TSSERVER_PREFERENCES: Required<ts.server.protocol.UserPreferences> = {
     allowIncompleteCompletions: true,
     allowRenameOfImportPath: true,
     allowTextChangesInNewFiles: true,
@@ -44,10 +45,10 @@ const DEFAULT_TSSERVER_PREFERENCES: Required<tsp.UserPreferences> = {
 const DEFAULT_IMPLICIT_PROJECT_CONFIGURATION: Required<WorkspaceConfigurationImplicitProjectConfigurationOptions> = {
     checkJs: false,
     experimentalDecorators: false,
-    module: tsp.ModuleKind.ESNext,
+    module: ModuleKind.ESNext,
     strictFunctionTypes: true,
     strictNullChecks: true,
-    target: tsp.ScriptTarget.ES2020,
+    target: ScriptTarget.ES2020,
 };
 
 const DEFAULT_WORKSPACE_CONFIGURATION: WorkspaceConfiguration = {
@@ -63,7 +64,7 @@ export interface WorkspaceConfiguration {
 }
 
 export interface WorkspaceConfigurationLanguageOptions {
-    format?: tsp.FormatCodeSettings;
+    format?: ts.server.protocol.FormatCodeSettings;
     inlayHints?: TypeScriptInlayHintsPreferences;
 }
 
@@ -78,7 +79,7 @@ export interface WorkspaceConfigurationImplicitProjectConfigurationOptions {
 
 /* eslint-disable @typescript-eslint/indent */
 export type TypeScriptInlayHintsPreferences = Pick<
-    tsp.UserPreferences,
+    ts.server.protocol.UserPreferences,
     'includeInlayParameterNameHints' |
     'includeInlayParameterNameHintsWhenArgumentMatchesName' |
     'includeInlayFunctionParameterTypeHints' |
@@ -99,13 +100,13 @@ export interface WorkspaceConfigurationCompletionOptions {
 }
 
 export class ConfigurationManager {
-    public tsPreferences: Required<tsp.UserPreferences> = deepmerge({}, DEFAULT_TSSERVER_PREFERENCES);
+    public tsPreferences: Required<ts.server.protocol.UserPreferences> = deepmerge({}, DEFAULT_TSSERVER_PREFERENCES);
     public workspaceConfiguration: WorkspaceConfiguration = deepmerge({}, DEFAULT_WORKSPACE_CONFIGURATION);
     private tspClient: TspClient | null = null;
 
     constructor(private readonly documents: LspDocuments) {}
 
-    public mergeTsPreferences(preferences: tsp.UserPreferences): void {
+    public mergeTsPreferences(preferences: ts.server.protocol.UserPreferences): void {
         this.tsPreferences = deepmerge(this.tsPreferences, preferences);
     }
 
@@ -115,11 +116,11 @@ export class ConfigurationManager {
 
     public setAndConfigureTspClient(workspaceFolder: string | undefined, client: TspClient, hostInfo?: TypeScriptInitializationOptions['hostInfo']): void {
         this.tspClient = client;
-        const formatOptions: tsp.FormatCodeSettings = {
+        const formatOptions: ts.server.protocol.FormatCodeSettings = {
             // We can use \n here since the editor should normalize later on to its line endings.
             newLineCharacter: '\n',
         };
-        const args: tsp.ConfigureRequestArguments = {
+        const args: ts.server.protocol.ConfigureRequestArguments = {
             ...hostInfo ? { hostInfo } : {},
             formatOptions,
             preferences: {
@@ -127,24 +128,24 @@ export class ConfigurationManager {
                 autoImportFileExcludePatterns: this.getAutoImportFileExcludePatternsPreference(workspaceFolder),
             },
         };
-        client.executeWithoutWaitingForResponse(tsp.CommandTypes.Configure, args);
+        client.executeWithoutWaitingForResponse(CommandTypes.Configure, args);
     }
 
     public async configureGloballyFromDocument(filename: string, formattingOptions?: lsp.FormattingOptions): Promise<void> {
-        const args: tsp.ConfigureRequestArguments = {
+        const args: ts.server.protocol.ConfigureRequestArguments = {
             formatOptions: this.getFormattingOptions(filename, formattingOptions),
             preferences: this.getPreferences(filename),
         };
-        await this.tspClient?.request(tsp.CommandTypes.Configure, args);
+        await this.tspClient?.request(CommandTypes.Configure, args);
     }
 
-    public getPreferences(filename: string): tsp.UserPreferences {
+    public getPreferences(filename: string): ts.server.protocol.UserPreferences {
         if (this.tspClient?.apiVersion.lt(API.v290)) {
             return {};
         }
 
         const workspacePreferences = this.getWorkspacePreferencesForFile(filename);
-        const preferences = Object.assign<tsp.UserPreferences, tsp.UserPreferences, tsp.UserPreferences>(
+        const preferences = Object.assign<ts.server.protocol.UserPreferences, ts.server.protocol.UserPreferences, ts.server.protocol.UserPreferences>(
             {},
             this.tsPreferences,
             workspacePreferences?.inlayHints || {},
@@ -156,10 +157,10 @@ export class ConfigurationManager {
         };
     }
 
-    private getFormattingOptions(filename: string, formattingOptions?: lsp.FormattingOptions): tsp.FormatCodeSettings {
+    private getFormattingOptions(filename: string, formattingOptions?: lsp.FormattingOptions): ts.server.protocol.FormatCodeSettings {
         const workspacePreferences = this.getWorkspacePreferencesForFile(filename);
 
-        const opts: tsp.FormatCodeSettings = {
+        const opts: ts.server.protocol.FormatCodeSettings = {
             ...workspacePreferences?.format,
             ...formattingOptions,
         };
@@ -174,7 +175,7 @@ export class ConfigurationManager {
         return opts;
     }
 
-    private getQuoteStylePreference(preferences: tsp.UserPreferences) {
+    private getQuoteStylePreference(preferences: ts.server.protocol.UserPreferences) {
         switch (preferences.quotePreference) {
             case 'single': return 'single';
             case 'double': return 'double';

--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -9,12 +9,13 @@ import * as lsp from 'vscode-languageserver';
 import debounce from 'p-debounce';
 import { Logger } from './utils/logger.js';
 import { pathToUri, toDiagnostic } from './protocol-translation.js';
-import type { tsp, EventTypes } from './ts-protocol.js';
+import { EventTypes } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import { LspDocuments } from './document.js';
 import { SupportedFeatures } from './ts-protocol.js';
 
 class FileDiagnostics {
-    private readonly diagnosticsPerKind = new Map<EventTypes, tsp.Diagnostic[]>();
+    private readonly diagnosticsPerKind = new Map<EventTypes, ts.server.protocol.Diagnostic[]>();
 
     constructor(
         protected readonly uri: string,
@@ -23,7 +24,7 @@ class FileDiagnostics {
         protected readonly features: SupportedFeatures,
     ) { }
 
-    update(kind: EventTypes, diagnostics: tsp.Diagnostic[]): void {
+    update(kind: EventTypes, diagnostics: ts.server.protocol.Diagnostic[]): void {
         this.diagnosticsPerKind.set(kind, diagnostics);
         this.firePublishDiagnostics();
     }
@@ -54,7 +55,7 @@ export class DiagnosticEventQueue {
         protected readonly logger: Logger,
     ) { }
 
-    updateDiagnostics(kind: EventTypes, event: tsp.DiagnosticEvent): void {
+    updateDiagnostics(kind: EventTypes, event: ts.server.protocol.DiagnosticEvent): void {
         if (!event.body) {
             this.logger.error(`Received empty ${event.event} diagnostics.`);
             return;
@@ -81,7 +82,7 @@ export class DiagnosticEventQueue {
         return this.diagnostics.get(uri)?.getDiagnostics() || [];
     }
 
-    private isDiagnosticIgnored(diagnostic: tsp.Diagnostic) : boolean {
+    private isDiagnosticIgnored(diagnostic: ts.server.protocol.Diagnostic) : boolean {
         return diagnostic.code !== undefined && this.ignoredDiagnosticCodes.has(diagnostic.code);
     }
 }

--- a/src/document-symbol.ts
+++ b/src/document-symbol.ts
@@ -7,14 +7,15 @@
 
 import * as lsp from 'vscode-languageserver';
 import { toSymbolKind } from './protocol-translation.js';
-import { tslib, tsp } from './ts-protocol.js';
+import { ScriptElementKind } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import { Range } from './utils/typeConverters.js';
 
-export function collectDocumentSymbols(parent: tsp.NavigationTree, symbols: lsp.DocumentSymbol[]): boolean {
+export function collectDocumentSymbols(parent: ts.server.protocol.NavigationTree, symbols: lsp.DocumentSymbol[]): boolean {
     return collectDocumentSymbolsInRange(parent, symbols, { start: Range.fromTextSpan(parent.spans[0]).start, end: Range.fromTextSpan(parent.spans[parent.spans.length - 1]).end });
 }
 
-function collectDocumentSymbolsInRange(parent: tsp.NavigationTree, symbols: lsp.DocumentSymbol[], range: lsp.Range): boolean {
+function collectDocumentSymbolsInRange(parent: ts.server.protocol.NavigationTree, symbols: lsp.DocumentSymbol[], range: lsp.Range): boolean {
     let shouldInclude = shouldIncludeEntry(parent);
 
     for (const span of parent.spans) {
@@ -55,7 +56,7 @@ function collectDocumentSymbolsInRange(parent: tsp.NavigationTree, symbols: lsp.
     return shouldInclude;
 }
 
-export function collectSymbolInformation(uri: string, current: tsp.NavigationTree, symbols: lsp.SymbolInformation[], containerName?: string): boolean {
+export function collectSymbolInformation(uri: string, current: ts.server.protocol.NavigationTree, symbols: lsp.SymbolInformation[], containerName?: string): boolean {
     let shouldInclude = shouldIncludeEntry(current);
     const name = current.text;
     for (const span of current.spans) {
@@ -86,8 +87,8 @@ export function collectSymbolInformation(uri: string, current: tsp.NavigationTre
     return shouldInclude;
 }
 
-export function shouldIncludeEntry(item: tsp.NavigationTree | tsp.NavigationBarItem): boolean {
-    if (item.kind === tslib.ScriptElementKind.alias) {
+export function shouldIncludeEntry(item: ts.server.protocol.NavigationTree | ts.server.protocol.NavigationBarItem): boolean {
+    if (item.kind === ScriptElementKind.alias) {
         return false;
     }
     return !!(item.text && item.text !== '<function>' && item.text !== '<class>');

--- a/src/features/call-hierarchy.spec.ts
+++ b/src/features/call-hierarchy.spec.ts
@@ -7,7 +7,7 @@
 
 import * as chai from 'chai';
 import * as lsp from 'vscode-languageserver';
-import { uri, createServer, TestLspServer, positionAfter, documentFromFile } from './../test-utils.js';
+import { uri, createServer, TestLspServer, positionAfter, documentFromFile } from '../test-utils.js';
 
 const assert = chai.assert;
 
@@ -68,7 +68,7 @@ after(() => {
     server.shutdown();
 });
 
-describe.only('call hierarchy', () => {
+describe('call hierarchy', () => {
     const oneDoc = documentFromFile({ path: 'call-hierarchy/one.ts' });
     const twoDoc = documentFromFile({ path: 'call-hierarchy/two.ts' });
     const threeDoc = documentFromFile({ path: 'call-hierarchy/three.ts' });

--- a/src/features/call-hierarchy.ts
+++ b/src/features/call-hierarchy.ts
@@ -13,10 +13,11 @@ import path from 'node:path';
 import * as lsp from 'vscode-languageserver';
 import type { LspDocuments } from '../document.js';
 import { pathToUri } from '../protocol-translation.js';
-import { tslib, tsp } from '../ts-protocol.js';
+import { ScriptElementKind, ScriptElementKindModifier } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import { Range } from '../utils/typeConverters.js';
 
-export function fromProtocolCallHierarchyItem(item: tsp.CallHierarchyItem, documents: LspDocuments, workspaceRoot: string | undefined): lsp.CallHierarchyItem {
+export function fromProtocolCallHierarchyItem(item: ts.server.protocol.CallHierarchyItem, documents: LspDocuments, workspaceRoot: string | undefined): lsp.CallHierarchyItem {
     const useFileName = isSourceFileItem(item);
     const name = useFileName ? path.basename(item.file) : item.name;
     const detail = useFileName
@@ -32,54 +33,54 @@ export function fromProtocolCallHierarchyItem(item: tsp.CallHierarchyItem, docum
     };
 
     const kindModifiers = item.kindModifiers ? parseKindModifier(item.kindModifiers) : undefined;
-    if (kindModifiers?.has(tslib.ScriptElementKindModifier.deprecatedModifier)) {
+    if (kindModifiers?.has(ScriptElementKindModifier.deprecatedModifier)) {
         result.tags = [lsp.SymbolTag.Deprecated];
     }
     return result;
 }
 
-export function fromProtocolCallHierarchyIncomingCall(item: tsp.CallHierarchyIncomingCall, documents: LspDocuments, workspaceRoot: string | undefined): lsp.CallHierarchyIncomingCall {
+export function fromProtocolCallHierarchyIncomingCall(item: ts.server.protocol.CallHierarchyIncomingCall, documents: LspDocuments, workspaceRoot: string | undefined): lsp.CallHierarchyIncomingCall {
     return {
         from: fromProtocolCallHierarchyItem(item.from, documents, workspaceRoot),
         fromRanges: item.fromSpans.map(Range.fromTextSpan),
     };
 }
 
-export function fromProtocolCallHierarchyOutgoingCall(item: tsp.CallHierarchyOutgoingCall, documents: LspDocuments, workspaceRoot: string | undefined): lsp.CallHierarchyOutgoingCall {
+export function fromProtocolCallHierarchyOutgoingCall(item: ts.server.protocol.CallHierarchyOutgoingCall, documents: LspDocuments, workspaceRoot: string | undefined): lsp.CallHierarchyOutgoingCall {
     return {
         to: fromProtocolCallHierarchyItem(item.to, documents, workspaceRoot),
         fromRanges: item.fromSpans.map(Range.fromTextSpan),
     };
 }
 
-function isSourceFileItem(item: tsp.CallHierarchyItem) {
-    return item.kind === tslib.ScriptElementKind.scriptElement || item.kind === tslib.ScriptElementKind.moduleElement && item.selectionSpan.start.line === 1 && item.selectionSpan.start.offset === 1;
+function isSourceFileItem(item: ts.server.protocol.CallHierarchyItem) {
+    return item.kind === ScriptElementKind.scriptElement || item.kind === ScriptElementKind.moduleElement && item.selectionSpan.start.line === 1 && item.selectionSpan.start.offset === 1;
 }
 
-function fromProtocolScriptElementKind(kind: tslib.ScriptElementKind): lsp.SymbolKind {
+function fromProtocolScriptElementKind(kind: ScriptElementKind): lsp.SymbolKind {
     switch (kind) {
-        case tslib.ScriptElementKind.moduleElement:return lsp.SymbolKind.Module;
-        case tslib.ScriptElementKind.classElement:return lsp.SymbolKind.Class;
-        case tslib.ScriptElementKind.enumElement:return lsp.SymbolKind.Enum;
-        case tslib.ScriptElementKind.enumMemberElement:return lsp.SymbolKind.EnumMember;
-        case tslib.ScriptElementKind.interfaceElement:return lsp.SymbolKind.Interface;
-        case tslib.ScriptElementKind.indexSignatureElement:return lsp.SymbolKind.Method;
-        case tslib.ScriptElementKind.callSignatureElement:return lsp.SymbolKind.Method;
-        case tslib.ScriptElementKind.memberFunctionElement:return lsp.SymbolKind.Method;
-        case tslib.ScriptElementKind.memberVariableElement:return lsp.SymbolKind.Property;
-        case tslib.ScriptElementKind.memberGetAccessorElement:return lsp.SymbolKind.Property;
-        case tslib.ScriptElementKind.memberSetAccessorElement:return lsp.SymbolKind.Property;
-        case tslib.ScriptElementKind.variableElement:return lsp.SymbolKind.Variable;
-        case tslib.ScriptElementKind.letElement:return lsp.SymbolKind.Variable;
-        case tslib.ScriptElementKind.constElement:return lsp.SymbolKind.Variable;
-        case tslib.ScriptElementKind.localVariableElement:return lsp.SymbolKind.Variable;
-        case tslib.ScriptElementKind.alias:return lsp.SymbolKind.Variable;
-        case tslib.ScriptElementKind.functionElement:return lsp.SymbolKind.Function;
-        case tslib.ScriptElementKind.localFunctionElement:return lsp.SymbolKind.Function;
-        case tslib.ScriptElementKind.constructSignatureElement:return lsp.SymbolKind.Constructor;
-        case tslib.ScriptElementKind.constructorImplementationElement:return lsp.SymbolKind.Constructor;
-        case tslib.ScriptElementKind.typeParameterElement:return lsp.SymbolKind.TypeParameter;
-        case tslib.ScriptElementKind.string:return lsp.SymbolKind.String;
+        case ScriptElementKind.moduleElement:return lsp.SymbolKind.Module;
+        case ScriptElementKind.classElement:return lsp.SymbolKind.Class;
+        case ScriptElementKind.enumElement:return lsp.SymbolKind.Enum;
+        case ScriptElementKind.enumMemberElement:return lsp.SymbolKind.EnumMember;
+        case ScriptElementKind.interfaceElement:return lsp.SymbolKind.Interface;
+        case ScriptElementKind.indexSignatureElement:return lsp.SymbolKind.Method;
+        case ScriptElementKind.callSignatureElement:return lsp.SymbolKind.Method;
+        case ScriptElementKind.memberFunctionElement:return lsp.SymbolKind.Method;
+        case ScriptElementKind.memberVariableElement:return lsp.SymbolKind.Property;
+        case ScriptElementKind.memberGetAccessorElement:return lsp.SymbolKind.Property;
+        case ScriptElementKind.memberSetAccessorElement:return lsp.SymbolKind.Property;
+        case ScriptElementKind.variableElement:return lsp.SymbolKind.Variable;
+        case ScriptElementKind.letElement:return lsp.SymbolKind.Variable;
+        case ScriptElementKind.constElement:return lsp.SymbolKind.Variable;
+        case ScriptElementKind.localVariableElement:return lsp.SymbolKind.Variable;
+        case ScriptElementKind.alias:return lsp.SymbolKind.Variable;
+        case ScriptElementKind.functionElement:return lsp.SymbolKind.Function;
+        case ScriptElementKind.localFunctionElement:return lsp.SymbolKind.Function;
+        case ScriptElementKind.constructSignatureElement:return lsp.SymbolKind.Constructor;
+        case ScriptElementKind.constructorImplementationElement:return lsp.SymbolKind.Constructor;
+        case ScriptElementKind.typeParameterElement:return lsp.SymbolKind.TypeParameter;
+        case ScriptElementKind.string:return lsp.SymbolKind.String;
         default: return lsp.SymbolKind.Variable;
     }
 }

--- a/src/features/fix-all.ts
+++ b/src/features/fix-all.ts
@@ -6,14 +6,13 @@
 import * as lsp from 'vscode-languageserver';
 import { LspDocuments } from '../document.js';
 import { toTextDocumentEdit } from '../protocol-translation.js';
-import { tsp } from '../ts-protocol.js';
+import { CommandTypes } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import { TspClient } from '../tsp-client.js';
 import * as errorCodes from '../utils/errorCodes.js';
 import * as fixNames from '../utils/fixNames.js';
 import { CodeActionKind } from '../utils/types.js';
 import { Range } from '../utils/typeConverters.js';
-
-import CommandTypes = tsp.CommandTypes;
 
 interface AutoFix {
     readonly codes: Set<number>;
@@ -34,7 +33,7 @@ async function buildIndividualFixes(
                 continue;
             }
 
-            const args: tsp.CodeFixRequestArgs = {
+            const args: ts.server.protocol.CodeFixRequestArgs = {
                 ...Range.toFileRangeRequestArgs(file, diagnostic.range),
                 errorCodes: [+diagnostic.code!],
             };
@@ -68,7 +67,7 @@ async function buildCombinedFix(
                 continue;
             }
 
-            const args: tsp.CodeFixRequestArgs = {
+            const args: ts.server.protocol.CodeFixRequestArgs = {
                 ...Range.toFileRangeRequestArgs(file, diagnostic.range),
                 errorCodes: [+diagnostic.code!],
             };
@@ -88,7 +87,7 @@ async function buildCombinedFix(
                 return edits;
             }
 
-            const combinedArgs: tsp.GetCombinedCodeFixRequestArgs = {
+            const combinedArgs: ts.server.protocol.GetCombinedCodeFixRequestArgs = {
                 scope: {
                     type: 'file',
                     args: { file },

--- a/src/features/inlay-hints.ts
+++ b/src/features/inlay-hints.ts
@@ -13,7 +13,8 @@ import * as lsp from 'vscode-languageserver';
 import API from '../utils/api.js';
 import type { ConfigurationManager } from '../configuration-manager.js';
 import type { LspDocuments } from '../document.js';
-import { tsp } from '../ts-protocol.js';
+import { CommandTypes } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import type { TspClient } from '../tsp-client.js';
 import type { LspClient } from '../lsp-client.js';
 import { Position } from '../utils/typeConverters.js';
@@ -58,7 +59,7 @@ export class TypeScriptInlayHintsProvider {
         const start = document.offsetAt(range.start);
         const length = document.offsetAt(range.end) - start;
 
-        const response = await tspClient.request(tsp.CommandTypes.ProvideInlayHints, { file, start, length });
+        const response = await tspClient.request(CommandTypes.ProvideInlayHints, { file, start, length });
         if (response.type !== 'response' || !response.success || !response.body) {
             return [];
         }
@@ -89,7 +90,7 @@ function areInlayHintsEnabledForFile(configurationManager: ConfigurationManager,
         preferences.includeInlayVariableTypeHints;
 }
 
-function fromProtocolInlayHintKind(kind: tsp.InlayHintKind): lsp.InlayHintKind | undefined {
+function fromProtocolInlayHintKind(kind: ts.server.protocol.InlayHintKind): lsp.InlayHintKind | undefined {
     switch (kind) {
         case 'Parameter': return lsp.InlayHintKind.Parameter;
         case 'Type': return lsp.InlayHintKind.Type;

--- a/src/features/source-definition.ts
+++ b/src/features/source-definition.ts
@@ -16,7 +16,7 @@ import { toLocation, uriToPath } from '../protocol-translation.js';
 import type { LspDocuments } from '../document.js';
 import type { TspClient } from '../tsp-client.js';
 import type { LspClient } from '../lsp-client.js';
-import { tsp } from '../ts-protocol.js';
+import { CommandTypes } from '../ts-protocol.js';
 
 export class SourceDefinitionCommand {
     public static readonly id = '_typescript.goToSourceDefinition';
@@ -59,7 +59,7 @@ export class SourceDefinitionCommand {
             message: 'Finding source definitions…',
             reporter,
         }, async () => {
-            const response = await tspClient.request(tsp.CommandTypes.FindSourceDefinition, args);
+            const response = await tspClient.request(CommandTypes.FindSourceDefinition, args);
             if (response.type !== 'response' || !response.body) {
                 lspClient.showErrorMessage('No source definitions found.');
                 return;

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -10,12 +10,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as lsp from 'vscode-languageserver';
-import type { tsp } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import * as Previewer from './utils/previewer.js';
 import { IFilePathToResourceConverter } from './utils/previewer.js';
 
 export function asSignatureHelp(
-    info: tsp.SignatureHelpItems,
+    info: ts.server.protocol.SignatureHelpItems,
     context: lsp.SignatureHelpContext | undefined,
     filePathConverter: IFilePathToResourceConverter,
 ): lsp.SignatureHelp {
@@ -27,7 +27,7 @@ export function asSignatureHelp(
     };
 }
 
-function getActiveSignature(info: tsp.SignatureHelpItems, signatures: readonly lsp.SignatureInformation[], context?: lsp.SignatureHelpContext): number {
+function getActiveSignature(info: ts.server.protocol.SignatureHelpItems, signatures: readonly lsp.SignatureInformation[], context?: lsp.SignatureHelpContext): number {
     // Try matching the previous active signature's label to keep it selected
     if (context?.activeSignatureHelp?.activeSignature !== undefined) {
         const previouslyActiveSignature = context.activeSignatureHelp.signatures[context.activeSignatureHelp.activeSignature];
@@ -42,7 +42,7 @@ function getActiveSignature(info: tsp.SignatureHelpItems, signatures: readonly l
     return info.selectedItemIndex;
 }
 
-function getActiveParameter(info: tsp.SignatureHelpItems): number {
+function getActiveParameter(info: ts.server.protocol.SignatureHelpItems): number {
     const activeSignature = info.items[info.selectedItemIndex];
     if (activeSignature?.isVariadic) {
         return Math.min(info.argumentIndex, activeSignature.parameters.length - 1);
@@ -50,7 +50,7 @@ function getActiveParameter(info: tsp.SignatureHelpItems): number {
     return info.argumentIndex;
 }
 
-function asSignatureInformation(item: tsp.SignatureHelpItem, filePathConverter: IFilePathToResourceConverter): lsp.SignatureInformation {
+function asSignatureInformation(item: ts.server.protocol.SignatureHelpItem, filePathConverter: IFilePathToResourceConverter): lsp.SignatureInformation {
     const parameters = item.parameters.map(parameter => asParameterInformation(parameter, filePathConverter));
     const signature: lsp.SignatureInformation = {
         label: Previewer.plainWithLinks(item.prefixDisplayParts, filePathConverter),
@@ -62,7 +62,7 @@ function asSignatureInformation(item: tsp.SignatureHelpItem, filePathConverter: 
     return signature;
 }
 
-function asParameterInformation(parameter: tsp.SignatureHelpParameter, filePathConverter: IFilePathToResourceConverter): lsp.ParameterInformation {
+function asParameterInformation(parameter: ts.server.protocol.SignatureHelpParameter, filePathConverter: IFilePathToResourceConverter): lsp.ParameterInformation {
     const { displayParts, documentation } = parameter;
     return {
         label: Previewer.plainWithLinks(displayParts, filePathConverter),
@@ -70,7 +70,7 @@ function asParameterInformation(parameter: tsp.SignatureHelpParameter, filePathC
     };
 }
 
-export function toTsTriggerReason(context: lsp.SignatureHelpContext): tsp.SignatureHelpTriggerReason {
+export function toTsTriggerReason(context: lsp.SignatureHelpContext): ts.server.protocol.SignatureHelpTriggerReason {
     switch (context.triggerKind) {
         case lsp.SignatureHelpTriggerKind.TriggerCharacter:
             if (context.triggerCharacter) {

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -11,7 +11,7 @@ import * as lsp from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { uri, createServer, position, lastPosition, filePath, positionAfter, readContents, TestLspServer, toPlatformEOL } from './test-utils.js';
 import { Commands } from './commands.js';
-import { tslib } from './ts-protocol.js';
+import { SemicolonPreference } from './ts-protocol.js';
 import { CodeActionKind } from './utils/types.js';
 
 const assert = chai.assert;
@@ -58,7 +58,7 @@ describe('completion', () => {
         const proposals = await server.completion({ textDocument: doc, position: pos });
         assert.isNotNull(proposals);
         assert.isAtLeast(proposals!.items.length, 800);
-        const item = proposals!.items.find(i => i.label === 'addEventListener');
+        const item = proposals!.items.find(i => i.label === 'setTimeout');
         assert.isDefined(item);
         const resolvedItem = await server.completionResolve(item!);
         assert.isNotTrue(resolvedItem.deprecated, 'resolved item is not deprecated');
@@ -368,7 +368,7 @@ describe('completion', () => {
         server.updateWorkspaceSettings({
             typescript: {
                 format: {
-                    semicolons: tslib.SemicolonPreference.Remove,
+                    semicolons: SemicolonPreference.Remove,
                     insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false,
                 },
             },
@@ -405,7 +405,7 @@ describe('completion', () => {
         server.updateWorkspaceSettings({
             typescript: {
                 format: {
-                    semicolons: tslib.SemicolonPreference.Ignore,
+                    semicolons: SemicolonPreference.Ignore,
                     insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
                 },
             },
@@ -1172,7 +1172,7 @@ describe('formatting', () => {
         server.updateWorkspaceSettings({
             typescript: {
                 format: {
-                    semicolons: tslib.SemicolonPreference.Ignore,
+                    semicolons: SemicolonPreference.Ignore,
                     insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
                 },
             },

--- a/src/organize-imports.spec.ts
+++ b/src/organize-imports.spec.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import { provideOrganizeImports } from './organize-imports.js';
 import { filePath, uri } from './test-utils.js';
-import type { tsp } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import { CodeActionKind } from './utils/types.js';
 
 describe('provideOrganizeImports', () => {
@@ -15,7 +15,7 @@ describe('provideOrganizeImports', () => {
                 },
             ],
         };
-        const actual = provideOrganizeImports(response as any as tsp.OrganizeImportsResponse, undefined);
+        const actual = provideOrganizeImports(response as any as ts.server.protocol.OrganizeImportsResponse, undefined);
         const expected = [{
             title: 'Organize imports',
             kind: CodeActionKind.SourceOrganizeImportsTs.value,

--- a/src/organize-imports.ts
+++ b/src/organize-imports.ts
@@ -8,10 +8,10 @@
 import * as lsp from 'vscode-languageserver';
 import { toTextDocumentEdit } from './protocol-translation.js';
 import { LspDocuments } from './document.js';
-import type { tsp } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import { CodeActionKind } from './utils/types.js';
 
-export function provideOrganizeImports(response: tsp.OrganizeImportsResponse | undefined, documents: LspDocuments | undefined): Array<lsp.CodeAction> {
+export function provideOrganizeImports(response: ts.server.protocol.OrganizeImportsResponse | undefined, documents: LspDocuments | undefined): Array<lsp.CodeAction> {
     if (!response || response.body.length === 0) {
         return [];
     }

--- a/src/quickfix.ts
+++ b/src/quickfix.ts
@@ -8,10 +8,10 @@
 import * as lsp from 'vscode-languageserver';
 import { Commands } from './commands.js';
 import { toTextDocumentEdit } from './protocol-translation.js';
-import type { tsp } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
 import { LspDocuments } from './document.js';
 
-export function provideQuickFix(response: tsp.GetCodeFixesResponse | undefined, documents: LspDocuments | undefined): Array<lsp.CodeAction> {
+export function provideQuickFix(response: ts.server.protocol.GetCodeFixesResponse | undefined, documents: LspDocuments | undefined): Array<lsp.CodeAction> {
     if (!response?.body) {
         return [];
     }

--- a/src/refactor.ts
+++ b/src/refactor.ts
@@ -7,9 +7,9 @@
 
 import * as lsp from 'vscode-languageserver';
 import { Commands } from './commands.js';
-import type { tsp, SupportedFeatures } from './ts-protocol.js';
+import type { ts, SupportedFeatures } from './ts-protocol.js';
 
-export function provideRefactors(response: tsp.GetApplicableRefactorsResponse | undefined, args: tsp.FileRangeRequestArgs, features: SupportedFeatures): lsp.CodeAction[] {
+export function provideRefactors(response: ts.server.protocol.GetApplicableRefactorsResponse | undefined, args: ts.server.protocol.FileRangeRequestArgs, features: SupportedFeatures): lsp.CodeAction[] {
     if (!response?.body) {
         return [];
     }
@@ -29,7 +29,7 @@ export function provideRefactors(response: tsp.GetApplicableRefactorsResponse | 
     return actions;
 }
 
-export function asSelectRefactoring(info: tsp.ApplicableRefactorInfo, args: tsp.FileRangeRequestArgs): lsp.CodeAction {
+export function asSelectRefactoring(info: ts.server.protocol.ApplicableRefactorInfo, args: ts.server.protocol.FileRangeRequestArgs): lsp.CodeAction {
     return lsp.CodeAction.create(
         info.description,
         lsp.Command.create(info.description, Commands.SELECT_REFACTORING, info, args),
@@ -37,7 +37,7 @@ export function asSelectRefactoring(info: tsp.ApplicableRefactorInfo, args: tsp.
     );
 }
 
-export function asApplyRefactoring(action: tsp.RefactorActionInfo, info: tsp.ApplicableRefactorInfo, args: tsp.FileRangeRequestArgs): lsp.CodeAction {
+export function asApplyRefactoring(action: ts.server.protocol.RefactorActionInfo, info: ts.server.protocol.ApplicableRefactorInfo, args: ts.server.protocol.FileRangeRequestArgs): lsp.CodeAction {
     const codeAction = lsp.CodeAction.create(action.description, asKind(info));
     if (action.notApplicableReason) {
         codeAction.disabled = { reason: action.notApplicableReason };
@@ -55,7 +55,7 @@ export function asApplyRefactoring(action: tsp.RefactorActionInfo, info: tsp.App
     return codeAction;
 }
 
-function asKind(refactor: tsp.RefactorActionInfo): lsp.CodeActionKind {
+function asKind(refactor: ts.server.protocol.RefactorActionInfo): lsp.CodeActionKind {
     if (refactor.name.startsWith('function_')) {
         return `${lsp.CodeActionKind.RefactorExtract}.function`;
     } else if (refactor.name.startsWith('constant_')) {

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -9,25 +9,240 @@
  * **IMPORTANT** this module should not depend on `vscode-languageserver` only protocol and types
  */
 import lsp from 'vscode-languageserver-protocol';
-import tslib from 'typescript/lib/tsserverlibrary.js';
+import type ts from 'typescript/lib/tsserverlibrary.js';
 import type { TraceValue } from './tsServer/tracer.js';
 
-import tsp = tslib.server.protocol;
-
-export { tslib, tsp };
+export type { ts };
 
 export namespace TypeScriptRenameRequest {
     export const type = new lsp.RequestType<lsp.TextDocumentPositionParams, void, void>('_typescript.rename');
 }
 
-declare module 'typescript/lib/tsserverlibrary.js' {
-    namespace server.protocol {
-        enum CommandTypes {
-            // Needed because it's not considered part of the public API - https://github.com/microsoft/TypeScript/issues/51410
-            EncodedSemanticClassificationsFull = 'encodedSemanticClassifications-full',
-        }
-    }
+// START: Duplicated from typescript/lib/tsserverlibrary.js since we don't want to depend on typescript at runtime
+
+export enum CommandTypes {
+    JsxClosingTag = 'jsxClosingTag',
+    Brace = 'brace',
+    BraceCompletion = 'braceCompletion',
+    GetSpanOfEnclosingComment = 'getSpanOfEnclosingComment',
+    Change = 'change',
+    Close = 'close',
+    /** @deprecated Prefer CompletionInfo -- see comment on CompletionsResponse */
+    Completions = 'completions',
+    CompletionInfo = 'completionInfo',
+    CompletionDetails = 'completionEntryDetails',
+    CompileOnSaveAffectedFileList = 'compileOnSaveAffectedFileList',
+    CompileOnSaveEmitFile = 'compileOnSaveEmitFile',
+    Configure = 'configure',
+    Definition = 'definition',
+    DefinitionAndBoundSpan = 'definitionAndBoundSpan',
+    // Not considered part of the public API - https://github.com/microsoft/TypeScript/issues/51410
+    EncodedSemanticClassificationsFull = 'encodedSemanticClassifications-full',
+    Implementation = 'implementation',
+    Exit = 'exit',
+    FileReferences = 'fileReferences',
+    Format = 'format',
+    Formatonkey = 'formatonkey',
+    Geterr = 'geterr',
+    GeterrForProject = 'geterrForProject',
+    SemanticDiagnosticsSync = 'semanticDiagnosticsSync',
+    SyntacticDiagnosticsSync = 'syntacticDiagnosticsSync',
+    SuggestionDiagnosticsSync = 'suggestionDiagnosticsSync',
+    NavBar = 'navbar',
+    Navto = 'navto',
+    NavTree = 'navtree',
+    NavTreeFull = 'navtree-full',
+    /** @deprecated */
+    Occurrences = 'occurrences',
+    DocumentHighlights = 'documentHighlights',
+    Open = 'open',
+    Quickinfo = 'quickinfo',
+    References = 'references',
+    Reload = 'reload',
+    Rename = 'rename',
+    Saveto = 'saveto',
+    SignatureHelp = 'signatureHelp',
+    FindSourceDefinition = 'findSourceDefinition',
+    Status = 'status',
+    TypeDefinition = 'typeDefinition',
+    ProjectInfo = 'projectInfo',
+    ReloadProjects = 'reloadProjects',
+    Unknown = 'unknown',
+    OpenExternalProject = 'openExternalProject',
+    OpenExternalProjects = 'openExternalProjects',
+    CloseExternalProject = 'closeExternalProject',
+    UpdateOpen = 'updateOpen',
+    GetOutliningSpans = 'getOutliningSpans',
+    TodoComments = 'todoComments',
+    Indentation = 'indentation',
+    DocCommentTemplate = 'docCommentTemplate',
+    CompilerOptionsForInferredProjects = 'compilerOptionsForInferredProjects',
+    GetCodeFixes = 'getCodeFixes',
+    GetCombinedCodeFix = 'getCombinedCodeFix',
+    ApplyCodeActionCommand = 'applyCodeActionCommand',
+    GetSupportedCodeFixes = 'getSupportedCodeFixes',
+    GetApplicableRefactors = 'getApplicableRefactors',
+    GetEditsForRefactor = 'getEditsForRefactor',
+    OrganizeImports = 'organizeImports',
+    GetEditsForFileRename = 'getEditsForFileRename',
+    ConfigurePlugin = 'configurePlugin',
+    SelectionRange = 'selectionRange',
+    ToggleLineComment = 'toggleLineComment',
+    ToggleMultilineComment = 'toggleMultilineComment',
+    CommentSelection = 'commentSelection',
+    UncommentSelection = 'uncommentSelection',
+    PrepareCallHierarchy = 'prepareCallHierarchy',
+    ProvideCallHierarchyIncomingCalls = 'provideCallHierarchyIncomingCalls',
+    ProvideCallHierarchyOutgoingCalls = 'provideCallHierarchyOutgoingCalls',
+    ProvideInlayHints = 'provideInlayHints'
 }
+
+export enum HighlightSpanKind {
+    none = 'none',
+    definition = 'definition',
+    reference = 'reference',
+    writtenReference = 'writtenReference'
+}
+
+export enum JsxEmit {
+    None = 'None',
+    Preserve = 'Preserve',
+    ReactNative = 'ReactNative',
+    React = 'React'
+}
+
+export enum ModuleKind {
+    None = 'None',
+    CommonJS = 'CommonJS',
+    AMD = 'AMD',
+    UMD = 'UMD',
+    System = 'System',
+    ES6 = 'ES6',
+    ES2015 = 'ES2015',
+    ESNext = 'ESNext'
+}
+
+export enum ModuleResolutionKind {
+    Classic = 'Classic',
+    Node = 'Node'
+}
+
+export enum SemicolonPreference {
+    Ignore = 'ignore',
+    Insert = 'insert',
+    Remove = 'remove'
+}
+
+export enum ScriptElementKind {
+    unknown = '',
+    warning = 'warning',
+    keyword = 'keyword',
+    scriptElement = 'script',
+    moduleElement = 'module',
+    classElement = 'class',
+    localClassElement = 'local class',
+    interfaceElement = 'interface',
+    typeElement = 'type',
+    enumElement = 'enum',
+    enumMemberElement = 'enum member',
+    variableElement = 'var',
+    localVariableElement = 'local var',
+    functionElement = 'function',
+    localFunctionElement = 'local function',
+    memberFunctionElement = 'method',
+    memberGetAccessorElement = 'getter',
+    memberSetAccessorElement = 'setter',
+    memberVariableElement = 'property',
+    memberAccessorVariableElement = 'accessor',
+    constructorImplementationElement = 'constructor',
+    callSignatureElement = 'call',
+    indexSignatureElement = 'index',
+    constructSignatureElement = 'construct',
+    parameterElement = 'parameter',
+    typeParameterElement = 'type parameter',
+    primitiveType = 'primitive type',
+    label = 'label',
+    alias = 'alias',
+    constElement = 'const',
+    letElement = 'let',
+    directory = 'directory',
+    externalModuleName = 'external module name',
+    jsxAttribute = 'JSX attribute',
+    string = 'string',
+    link = 'link',
+    linkName = 'link name',
+    linkText = 'link text'
+}
+
+export enum ScriptElementKindModifier {
+    none = '',
+    publicMemberModifier = 'public',
+    privateMemberModifier = 'private',
+    protectedMemberModifier = 'protected',
+    exportedModifier = 'export',
+    ambientModifier = 'declare',
+    staticModifier = 'static',
+    abstractModifier = 'abstract',
+    optionalModifier = 'optional',
+    deprecatedModifier = 'deprecated',
+    dtsModifier = '.d.ts',
+    tsModifier = '.ts',
+    tsxModifier = '.tsx',
+    jsModifier = '.js',
+    jsxModifier = '.jsx',
+    jsonModifier = '.json',
+    dmtsModifier = '.d.mts',
+    mtsModifier = '.mts',
+    mjsModifier = '.mjs',
+    dctsModifier = '.d.cts',
+    ctsModifier = '.cts',
+    cjsModifier = '.cjs'
+}
+
+export enum ScriptTarget {
+    ES3 = 'ES3',
+    ES5 = 'ES5',
+    ES6 = 'ES6',
+    ES2015 = 'ES2015',
+    ES2016 = 'ES2016',
+    ES2017 = 'ES2017',
+    ES2018 = 'ES2018',
+    ES2019 = 'ES2019',
+    ES2020 = 'ES2020',
+    ES2021 = 'ES2021',
+    ES2022 = 'ES2022',
+    ESNext = 'ESNext'
+}
+
+export enum SymbolDisplayPartKind {
+    aliasName = 0,
+    className = 1,
+    enumName = 2,
+    fieldName = 3,
+    interfaceName = 4,
+    keyword = 5,
+    lineBreak = 6,
+    numericLiteral = 7,
+    stringLiteral = 8,
+    localName = 9,
+    methodName = 10,
+    moduleName = 11,
+    operator = 12,
+    parameterName = 13,
+    propertyName = 14,
+    punctuation = 15,
+    space = 16,
+    text = 17,
+    typeParameterName = 18,
+    enumMemberName = 19,
+    functionName = 20,
+    regularExpressionLiteral = 21,
+    link = 22,
+    linkName = 23,
+    linkText = 24
+}
+
+// END: Duplicated from typescript/lib/tsserverlibrary.js since we don't want to depend on typescript at runtime
 
 export const enum EventTypes {
     ConfigFileDiag = 'configFileDiag',
@@ -58,7 +273,7 @@ export class KindModifiers {
     ];
 }
 
-const SYMBOL_DISPLAY_PART_KIND_MAP: Record<keyof typeof tslib.SymbolDisplayPartKind, tslib.SymbolDisplayPartKind> = {
+const SYMBOL_DISPLAY_PART_KIND_MAP: Record<keyof typeof ts.SymbolDisplayPartKind, ts.SymbolDisplayPartKind> = {
     aliasName: 0,
     className: 1,
     enumName: 2,
@@ -86,8 +301,8 @@ const SYMBOL_DISPLAY_PART_KIND_MAP: Record<keyof typeof tslib.SymbolDisplayPartK
     linkText: 24,
 };
 
-export function toSymbolDisplayPartKind(kind: string): tslib.SymbolDisplayPartKind {
-    return SYMBOL_DISPLAY_PART_KIND_MAP[kind as keyof typeof tslib.SymbolDisplayPartKind];
+export function toSymbolDisplayPartKind(kind: string): ts.SymbolDisplayPartKind {
+    return SYMBOL_DISPLAY_PART_KIND_MAP[kind as keyof typeof ts.SymbolDisplayPartKind];
 }
 
 export interface SupportedFeatures {
@@ -111,7 +326,7 @@ export interface TypeScriptInitializationOptions {
     maxTsServerMemory?: number;
     npmLocation?: string;
     plugins: TypeScriptPlugin[];
-    preferences?: tsp.UserPreferences;
+    preferences?: ts.server.protocol.UserPreferences;
     tsserver?: TsserverOptions;
 }
 

--- a/src/tsServer/callbackMap.ts
+++ b/src/tsServer/callbackMap.ts
@@ -10,7 +10,7 @@
  */
 
 import { ServerResponse } from './requests.js';
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 
 export interface CallbackItem<R> {
     readonly onSuccess: (value: R) => void;
@@ -19,7 +19,7 @@ export interface CallbackItem<R> {
     readonly isAsync: boolean;
 }
 
-export class CallbackMap<R extends tsp.Response> {
+export class CallbackMap<R extends ts.server.protocol.Response> {
     private readonly _callbacks = new Map<number, CallbackItem<ServerResponse.Response<R> | undefined>>();
     private readonly _asyncCallbacks = new Map<number, CallbackItem<ServerResponse.Response<R> | undefined>>();
 

--- a/src/tsServer/requestQueue.ts
+++ b/src/tsServer/requestQueue.ts
@@ -9,7 +9,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 
 export enum RequestQueueingType {
     /**
@@ -32,7 +32,7 @@ export enum RequestQueueingType {
 }
 
 export interface RequestItem {
-    readonly request: tsp.Request;
+    readonly request: ts.server.protocol.Request;
     readonly expectsResponse: boolean;
     readonly isAsync: boolean;
     readonly queueingType: RequestQueueingType;
@@ -76,7 +76,7 @@ export class RequestQueue {
         return false;
     }
 
-    public createRequest(command: string, args: any): tsp.Request {
+    public createRequest(command: string, args: any): ts.server.protocol.Request {
         return {
             seq: this.sequenceNumber++,
             type: 'request',

--- a/src/tsServer/requests.ts
+++ b/src/tsServer/requests.ts
@@ -10,10 +10,9 @@
  */
 
 import vscodeUri from 'vscode-uri';
-import { tsp } from '../ts-protocol.js';
+import { CommandTypes } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import { ExecutionTarget } from './server.js';
-
-import CommandTypes = tsp.CommandTypes;
 
 export enum ServerType {
     Syntax = 'syntax',
@@ -21,65 +20,58 @@ export enum ServerType {
 }
 
 export namespace ServerResponse {
-
     export class Cancelled {
         public readonly type = 'cancelled';
-
-        constructor(
-            public readonly reason: string,
-        ) { }
+        constructor(public readonly reason: string) {}
     }
-
     export const NoContent = { type: 'noContent' } as const;
-
     export const NoServer = { type: 'noServer' } as const;
-
-    export type Response<T extends tsp.Response> = T | Cancelled | typeof NoContent | typeof NoServer;
+    export type Response<T extends ts.server.protocol.Response> = T | Cancelled | typeof NoContent | typeof NoServer;
 }
 
 export interface TypeScriptRequestTypes {
-    [CommandTypes.ApplyCodeActionCommand]: [tsp.ApplyCodeActionCommandRequestArgs, tsp.ApplyCodeActionCommandResponse];
-    [CommandTypes.Change]: [tsp.ChangeRequestArgs, null];
-    [CommandTypes.Close]: [tsp.FileRequestArgs, null];
-    [CommandTypes.CompilerOptionsForInferredProjects]: [tsp.SetCompilerOptionsForInferredProjectsArgs, tsp.SetCompilerOptionsForInferredProjectsResponse];
-    [CommandTypes.CompletionDetails]: [tsp.CompletionDetailsRequestArgs, tsp.CompletionDetailsResponse];
-    [CommandTypes.CompletionInfo]: [tsp.CompletionsRequestArgs, tsp.CompletionInfoResponse];
-    [CommandTypes.Configure]: [tsp.ConfigureRequestArguments, tsp.ConfigureResponse];
-    [CommandTypes.ConfigurePlugin]: [tsp.ConfigurePluginRequestArguments, tsp.ConfigurePluginResponse];
-    [CommandTypes.Definition]: [tsp.FileLocationRequestArgs, tsp.DefinitionResponse];
-    [CommandTypes.DefinitionAndBoundSpan]: [tsp.FileLocationRequestArgs, tsp.DefinitionInfoAndBoundSpanResponse];
-    [CommandTypes.DocCommentTemplate]: [tsp.FileLocationRequestArgs, tsp.DocCommandTemplateResponse];
-    [CommandTypes.DocumentHighlights]: [tsp.DocumentHighlightsRequestArgs, tsp.DocumentHighlightsResponse];
-    [CommandTypes.EncodedSemanticClassificationsFull]: [tsp.EncodedSemanticClassificationsRequestArgs, tsp.EncodedSemanticClassificationsResponse];
-    [CommandTypes.FindSourceDefinition]: [tsp.FileLocationRequestArgs, tsp.DefinitionResponse];
-    [CommandTypes.Format]: [tsp.FormatRequestArgs, tsp.FormatResponse];
-    [CommandTypes.Formatonkey]: [tsp.FormatOnKeyRequestArgs, tsp.FormatResponse];
-    [CommandTypes.GetApplicableRefactors]: [tsp.GetApplicableRefactorsRequestArgs, tsp.GetApplicableRefactorsResponse];
-    [CommandTypes.GetCodeFixes]: [tsp.CodeFixRequestArgs, tsp.CodeFixResponse];
-    [CommandTypes.GetCombinedCodeFix]: [tsp.GetCombinedCodeFixRequestArgs, tsp.GetCombinedCodeFixResponse];
-    [CommandTypes.GetEditsForFileRename]: [tsp.GetEditsForFileRenameRequestArgs, tsp.GetEditsForFileRenameResponse];
-    [CommandTypes.GetEditsForRefactor]: [tsp.GetEditsForRefactorRequestArgs, tsp.GetEditsForRefactorResponse];
-    [CommandTypes.Geterr]: [tsp.GeterrRequestArgs, any];
-    [CommandTypes.GetOutliningSpans]: [tsp.FileRequestArgs, tsp.OutliningSpansResponse];
-    [CommandTypes.GetSupportedCodeFixes]: [null, tsp.GetSupportedCodeFixesResponse];
-    [CommandTypes.Implementation]: [tsp.FileLocationRequestArgs, tsp.ImplementationResponse];
-    [CommandTypes.JsxClosingTag]: [tsp.JsxClosingTagRequestArgs, tsp.JsxClosingTagResponse];
-    [CommandTypes.Navto]: [tsp.NavtoRequestArgs, tsp.NavtoResponse];
-    [CommandTypes.NavTree]: [tsp.FileRequestArgs, tsp.NavTreeResponse];
-    [CommandTypes.Open]: [tsp.OpenRequestArgs, null];
-    [CommandTypes.OrganizeImports]: [tsp.OrganizeImportsRequestArgs, tsp.OrganizeImportsResponse];
-    [CommandTypes.PrepareCallHierarchy]: [tsp.FileLocationRequestArgs, tsp.PrepareCallHierarchyResponse];
-    [CommandTypes.ProvideCallHierarchyIncomingCalls]: [tsp.FileLocationRequestArgs, tsp.ProvideCallHierarchyIncomingCallsResponse];
-    [CommandTypes.ProvideCallHierarchyOutgoingCalls]: [tsp.FileLocationRequestArgs, tsp.ProvideCallHierarchyOutgoingCallsResponse];
-    [CommandTypes.ProjectInfo]: [tsp.ProjectInfoRequestArgs, tsp.ProjectInfoResponse];
-    [CommandTypes.ProvideInlayHints]: [tsp.InlayHintsRequestArgs, tsp.InlayHintsResponse];
-    [CommandTypes.Quickinfo]: [tsp.FileLocationRequestArgs, tsp.QuickInfoResponse];
-    [CommandTypes.References]: [tsp.FileLocationRequestArgs, tsp.ReferencesResponse];
-    [CommandTypes.Rename]: [tsp.RenameRequestArgs, tsp.RenameResponse];
-    [CommandTypes.SelectionRange]: [tsp.SelectionRangeRequestArgs, tsp.SelectionRangeResponse];
-    [CommandTypes.SignatureHelp]: [tsp.SignatureHelpRequestArgs, tsp.SignatureHelpResponse];
-    [CommandTypes.TypeDefinition]: [tsp.FileLocationRequestArgs, tsp.TypeDefinitionResponse];
-    [CommandTypes.UpdateOpen]: [tsp.UpdateOpenRequestArgs, tsp.Response];
+    [CommandTypes.ApplyCodeActionCommand]: [ts.server.protocol.ApplyCodeActionCommandRequestArgs, ts.server.protocol.ApplyCodeActionCommandResponse];
+    [CommandTypes.Change]: [ts.server.protocol.ChangeRequestArgs, null];
+    [CommandTypes.Close]: [ts.server.protocol.FileRequestArgs, null];
+    [CommandTypes.CompilerOptionsForInferredProjects]: [ts.server.protocol.SetCompilerOptionsForInferredProjectsArgs, ts.server.protocol.SetCompilerOptionsForInferredProjectsResponse];
+    [CommandTypes.CompletionDetails]: [ts.server.protocol.CompletionDetailsRequestArgs, ts.server.protocol.CompletionDetailsResponse];
+    [CommandTypes.CompletionInfo]: [ts.server.protocol.CompletionsRequestArgs, ts.server.protocol.CompletionInfoResponse];
+    [CommandTypes.Configure]: [ts.server.protocol.ConfigureRequestArguments, ts.server.protocol.ConfigureResponse];
+    [CommandTypes.ConfigurePlugin]: [ts.server.protocol.ConfigurePluginRequestArguments, ts.server.protocol.ConfigurePluginResponse];
+    [CommandTypes.Definition]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DefinitionResponse];
+    [CommandTypes.DefinitionAndBoundSpan]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DefinitionInfoAndBoundSpanResponse];
+    [CommandTypes.DocCommentTemplate]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DocCommandTemplateResponse];
+    [CommandTypes.DocumentHighlights]: [ts.server.protocol.DocumentHighlightsRequestArgs, ts.server.protocol.DocumentHighlightsResponse];
+    [CommandTypes.EncodedSemanticClassificationsFull]: [ts.server.protocol.EncodedSemanticClassificationsRequestArgs, ts.server.protocol.EncodedSemanticClassificationsResponse];
+    [CommandTypes.FindSourceDefinition]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DefinitionResponse];
+    [CommandTypes.Format]: [ts.server.protocol.FormatRequestArgs, ts.server.protocol.FormatResponse];
+    [CommandTypes.Formatonkey]: [ts.server.protocol.FormatOnKeyRequestArgs, ts.server.protocol.FormatResponse];
+    [CommandTypes.GetApplicableRefactors]: [ts.server.protocol.GetApplicableRefactorsRequestArgs, ts.server.protocol.GetApplicableRefactorsResponse];
+    [CommandTypes.GetCodeFixes]: [ts.server.protocol.CodeFixRequestArgs, ts.server.protocol.CodeFixResponse];
+    [CommandTypes.GetCombinedCodeFix]: [ts.server.protocol.GetCombinedCodeFixRequestArgs, ts.server.protocol.GetCombinedCodeFixResponse];
+    [CommandTypes.GetEditsForFileRename]: [ts.server.protocol.GetEditsForFileRenameRequestArgs, ts.server.protocol.GetEditsForFileRenameResponse];
+    [CommandTypes.GetEditsForRefactor]: [ts.server.protocol.GetEditsForRefactorRequestArgs, ts.server.protocol.GetEditsForRefactorResponse];
+    [CommandTypes.Geterr]: [ts.server.protocol.GeterrRequestArgs, any];
+    [CommandTypes.GetOutliningSpans]: [ts.server.protocol.FileRequestArgs, ts.server.protocol.OutliningSpansResponse];
+    [CommandTypes.GetSupportedCodeFixes]: [null, ts.server.protocol.GetSupportedCodeFixesResponse];
+    [CommandTypes.Implementation]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.ImplementationResponse];
+    [CommandTypes.JsxClosingTag]: [ts.server.protocol.JsxClosingTagRequestArgs, ts.server.protocol.JsxClosingTagResponse];
+    [CommandTypes.Navto]: [ts.server.protocol.NavtoRequestArgs, ts.server.protocol.NavtoResponse];
+    [CommandTypes.NavTree]: [ts.server.protocol.FileRequestArgs, ts.server.protocol.NavTreeResponse];
+    [CommandTypes.Open]: [ts.server.protocol.OpenRequestArgs, null];
+    [CommandTypes.OrganizeImports]: [ts.server.protocol.OrganizeImportsRequestArgs, ts.server.protocol.OrganizeImportsResponse];
+    [CommandTypes.PrepareCallHierarchy]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.PrepareCallHierarchyResponse];
+    [CommandTypes.ProvideCallHierarchyIncomingCalls]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.ProvideCallHierarchyIncomingCallsResponse];
+    [CommandTypes.ProvideCallHierarchyOutgoingCalls]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.ProvideCallHierarchyOutgoingCallsResponse];
+    [CommandTypes.ProjectInfo]: [ts.server.protocol.ProjectInfoRequestArgs, ts.server.protocol.ProjectInfoResponse];
+    [CommandTypes.ProvideInlayHints]: [ts.server.protocol.InlayHintsRequestArgs, ts.server.protocol.InlayHintsResponse];
+    [CommandTypes.Quickinfo]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.QuickInfoResponse];
+    [CommandTypes.References]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.ReferencesResponse];
+    [CommandTypes.Rename]: [ts.server.protocol.RenameRequestArgs, ts.server.protocol.RenameResponse];
+    [CommandTypes.SelectionRange]: [ts.server.protocol.SelectionRangeRequestArgs, ts.server.protocol.SelectionRangeResponse];
+    [CommandTypes.SignatureHelp]: [ts.server.protocol.SignatureHelpRequestArgs, ts.server.protocol.SignatureHelpResponse];
+    [CommandTypes.TypeDefinition]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.TypeDefinitionResponse];
+    [CommandTypes.UpdateOpen]: [ts.server.protocol.UpdateOpenRequestArgs, ts.server.protocol.Response];
 }
 
 export type ExecConfig = {

--- a/src/tsServer/serverError.ts
+++ b/src/tsServer/serverError.ts
@@ -9,14 +9,14 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import type { TypeScriptVersion } from './versionProvider.js';
 
 export class TypeScriptServerError extends Error {
     public static create(
         serverId: string,
         version: TypeScriptVersion,
-        response: tsp.Response,
+        response: ts.server.protocol.Response,
     ): TypeScriptServerError {
         const parsedResult = TypeScriptServerError.parseErrorText(response);
         return new TypeScriptServerError(serverId, version, response, parsedResult?.message, parsedResult?.stack);
@@ -25,7 +25,7 @@ export class TypeScriptServerError extends Error {
     private constructor(
         public readonly serverId: string,
         public readonly version: TypeScriptVersion,
-        private readonly response: tsp.Response,
+        private readonly response: ts.server.protocol.Response,
         public readonly serverMessage: string | undefined,
         public readonly serverStack: string | undefined,
     ) {
@@ -43,7 +43,7 @@ export class TypeScriptServerError extends Error {
     /**
      * Given a `errorText` from a tsserver request indicating failure in handling a request.
      */
-    private static parseErrorText(response: tsp.Response) {
+    private static parseErrorText(response: ts.server.protocol.Response) {
         const errorText = response.message;
         if (errorText) {
             const errorPrefix = 'Error processing request. ';

--- a/src/tsServer/serverProcess.ts
+++ b/src/tsServer/serverProcess.ts
@@ -13,7 +13,7 @@ import ChildProcess from 'node:child_process';
 import path from 'node:path';
 import type { Readable } from 'node:stream';
 import { TsServerProcess, TsServerProcessFactory, TsServerProcessKind } from './server.js';
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import type { TspClientOptions } from '../tsp-client.js';
 import API from '../utils/api.js';
 import type { TypeScriptVersion } from './versionProvider.js';
@@ -94,11 +94,11 @@ class IpcChildServerProcess implements TsServerProcess {
         private readonly _process: ChildProcess.ChildProcess,
     ) {}
 
-    write(serverRequest: tsp.Request): void {
+    write(serverRequest: ts.server.protocol.Request): void {
         this._process.send(serverRequest);
     }
 
-    onData(handler: (data: tsp.Response) => void): void {
+    onData(handler: (data: ts.server.protocol.Response) => void): void {
         this._process.on('message', handler);
     }
 
@@ -120,23 +120,23 @@ class IpcChildServerProcess implements TsServerProcess {
 }
 
 class StdioChildServerProcess implements TsServerProcess {
-    private _reader: Reader<tsp.Response> | null;
+    private _reader: Reader<ts.server.protocol.Response> | null;
 
     constructor(
         private readonly _process: ChildProcess.ChildProcess,
     ) {
-        this._reader = new Reader<tsp.Response>(this._process.stdout!);
+        this._reader = new Reader<ts.server.protocol.Response>(this._process.stdout!);
     }
 
-    private get reader(): Reader<tsp.Response> {
+    private get reader(): Reader<ts.server.protocol.Response> {
         return this._reader!;
     }
 
-    write(serverRequest: tsp.Request): void {
+    write(serverRequest: ts.server.protocol.Request): void {
         this._process.stdin!.write(`${JSON.stringify(serverRequest)}\r\n`, 'utf8');
     }
 
-    onData(handler: (data: tsp.Response) => void): void {
+    onData(handler: (data: ts.server.protocol.Response) => void): void {
         this.reader.onData(handler);
     }
 

--- a/src/tsServer/tracer.ts
+++ b/src/tsServer/tracer.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-unnecessary-qualifier */
 
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import { Logger } from '../utils/logger.js';
 
 export enum Trace {
@@ -49,7 +49,7 @@ export default class Tracer {
     ) {
     }
 
-    public traceRequest(serverId: string, request: tsp.Request, responseExpected: boolean, queueLength: number): void {
+    public traceRequest(serverId: string, request: ts.server.protocol.Request, responseExpected: boolean, queueLength: number): void {
         if (this.trace === Trace.Off) {
             return;
         }
@@ -60,7 +60,7 @@ export default class Tracer {
         this.logTrace(serverId, `Sending request: ${request.command} (${request.seq}). Response expected: ${responseExpected ? 'yes' : 'no'}. Current queue length: ${queueLength}`, data);
     }
 
-    public traceResponse(serverId: string, response: tsp.Response, meta: RequestExecutionMetadata): void {
+    public traceResponse(serverId: string, response: ts.server.protocol.Response, meta: RequestExecutionMetadata): void {
         if (this.trace === Trace.Off) {
             return;
         }
@@ -78,7 +78,7 @@ export default class Tracer {
         this.logTrace(serverId, `Async response received: ${command} (${request_seq}). Request took ${Date.now() - meta.queuingStartTime} ms.`);
     }
 
-    public traceEvent(serverId: string, event: tsp.Event): void {
+    public traceEvent(serverId: string, event: ts.server.protocol.Event): void {
         if (this.trace === Trace.Off) {
             return;
         }

--- a/src/tsp-client.spec.ts
+++ b/src/tsp-client.spec.ts
@@ -9,13 +9,11 @@ import * as chai from 'chai';
 import { TspClient } from './tsp-client.js';
 import { ConsoleLogger } from './utils/logger.js';
 import { filePath, readContents, TestLspClient, uri } from './test-utils.js';
-import { tsp } from './ts-protocol.js';
+import { CommandTypes } from './ts-protocol.js';
 import { Trace } from './tsServer/tracer.js';
 import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
 import { TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration.js';
 import { noopLogDirectoryProvider } from './tsServer/logDirectoryProvider.js';
-
-import CommandTypes = tsp.CommandTypes;
 
 const assert = chai.assert;
 const logger = new ConsoleLogger();
@@ -65,7 +63,7 @@ describe('ts server client', () => {
             prefix: 'im',
         });
         assert.isDefined(completions.body);
-        assert.equal(completions.body!.entries[1].name, 'ImageBitmap');
+        assert.equal(completions.body!.entries[1].name, 'import');
     });
 
     it('references', async () => {

--- a/src/utils/modules-resolver.spec.ts
+++ b/src/utils/modules-resolver.spec.ts
@@ -5,7 +5,7 @@ import { findPathToModule } from './modules-resolver.js';
 import { PACKAGE_ROOT } from '../test-utils.js';
 import { MODULE_FOLDERS } from '../tsServer/versionProvider.js';
 
-export const CURDIR = dirname(fileURLToPath(import.meta.url));
+const CURDIR = dirname(fileURLToPath(import.meta.url));
 
 describe('findPathToModule', () => {
     it('resolves tsserver in own directory', () => {

--- a/src/utils/previewer.spec.ts
+++ b/src/utils/previewer.spec.ts
@@ -11,7 +11,7 @@
 
 import vscodeUri from 'vscode-uri';
 import * as chai from 'chai';
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 import { IFilePathToResourceConverter, markdownDocumentation, plainWithLinks, tagsMarkdownPreview } from './previewer.js';
 
 const assert = chai.assert;
@@ -155,7 +155,7 @@ describe('typescript.previewer', () => {
                         start: { line: 7, offset: 5 },
                         end: { line: 7, offset: 13 },
                     },
-                } as tsp.SymbolDisplayPart,
+                } as ts.server.protocol.SymbolDisplayPart,
                 { text: '}', kind: 'link' },
                 { text: ' b', kind: 'text' },
             ], noopToResource),
@@ -175,7 +175,7 @@ describe('typescript.previewer', () => {
                         start: { line: 7, offset: 5 },
                         end: { line: 7, offset: 13 },
                     },
-                } as tsp.SymbolDisplayPart,
+                } as ts.server.protocol.SymbolDisplayPart,
                 { text: 'husky', kind: 'linkText' },
                 { text: '}', kind: 'link' },
                 { text: ' b', kind: 'text' },

--- a/src/utils/previewer.ts
+++ b/src/utils/previewer.ts
@@ -12,7 +12,7 @@
 import vscodeUri from 'vscode-uri';
 import * as lsp from 'vscode-languageserver';
 import { MarkdownString } from './MarkdownString.js';
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 
 export interface IFilePathToResourceConverter {
     /**
@@ -40,7 +40,7 @@ function processInlineTags(text: string): string {
 }
 
 function getTagBodyText(
-    tag: tsp.JSDocTagInfo,
+    tag: ts.server.protocol.JSDocTagInfo,
     filePathConverter: IFilePathToResourceConverter,
 ): string | undefined {
     if (!tag.text) {
@@ -84,7 +84,7 @@ function getTagBodyText(
 }
 
 function getTagDocumentation(
-    tag: tsp.JSDocTagInfo,
+    tag: ts.server.protocol.JSDocTagInfo,
     filePathConverter: IFilePathToResourceConverter,
 ): string | undefined {
     switch (tag.name) {
@@ -115,7 +115,7 @@ function getTagDocumentation(
 }
 
 export function plainWithLinks(
-    parts: readonly tsp.SymbolDisplayPart[] | string,
+    parts: readonly ts.server.protocol.SymbolDisplayPart[] | string,
     filePathConverter: IFilePathToResourceConverter,
 ): string {
     return processInlineTags(convertLinkTags(parts, filePathConverter));
@@ -125,7 +125,7 @@ export function plainWithLinks(
  * Convert `@link` inline tags to markdown links
  */
 function convertLinkTags(
-    parts: readonly tsp.SymbolDisplayPart[] | string | undefined,
+    parts: readonly ts.server.protocol.SymbolDisplayPart[] | string | undefined,
     filePathConverter: IFilePathToResourceConverter,
 ): string {
     if (!parts) {
@@ -138,7 +138,7 @@ function convertLinkTags(
 
     const out: string[] = [];
 
-    let currentLink: { name?: string; target?: tsp.FileSpan; text?: string; readonly linkcode: boolean; } | undefined;
+    let currentLink: { name?: string; target?: ts.server.protocol.FileSpan; text?: string; readonly linkcode: boolean; } | undefined;
     for (const part of parts) {
         switch (part.kind) {
             case 'link':
@@ -178,7 +178,7 @@ function convertLinkTags(
             case 'linkName':
                 if (currentLink) {
                     currentLink.name = part.text;
-                    currentLink.target = (part as tsp.JSDocLinkDisplayPart).target;
+                    currentLink.target = (part as ts.server.protocol.JSDocLinkDisplayPart).target;
                 }
                 break;
 
@@ -197,15 +197,15 @@ function convertLinkTags(
 }
 
 export function tagsMarkdownPreview(
-    tags: readonly tsp.JSDocTagInfo[],
+    tags: readonly ts.server.protocol.JSDocTagInfo[],
     filePathConverter: IFilePathToResourceConverter,
 ): string {
     return tags.map(tag => getTagDocumentation(tag, filePathConverter)).join('  \n\n');
 }
 
 export function markdownDocumentation(
-    documentation: tsp.SymbolDisplayPart[] | string | undefined,
-    tags: tsp.JSDocTagInfo[] | undefined,
+    documentation: ts.server.protocol.SymbolDisplayPart[] | string | undefined,
+    tags: ts.server.protocol.JSDocTagInfo[] | undefined,
     filePathConverter: IFilePathToResourceConverter,
 ): lsp.MarkupContent | undefined {
     const out = new MarkdownString();
@@ -215,8 +215,8 @@ export function markdownDocumentation(
 
 export function addMarkdownDocumentation(
     out: MarkdownString,
-    documentation: string | tsp.SymbolDisplayPart[] | undefined,
-    tags: tsp.JSDocTagInfo[] | undefined,
+    documentation: string | ts.server.protocol.SymbolDisplayPart[] | undefined,
+    tags: ts.server.protocol.JSDocTagInfo[] | undefined,
     converter: IFilePathToResourceConverter,
 ): MarkdownString {
     if (documentation) {

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -10,18 +10,19 @@
  */
 
 import type { WorkspaceConfigurationImplicitProjectConfigurationOptions } from '../configuration-manager.js';
-import { tsp } from '../ts-protocol.js';
+import { ModuleKind, ModuleResolutionKind, ScriptTarget, JsxEmit } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 
-const DEFAULT_PROJECT_CONFIG: tsp.ExternalProjectCompilerOptions = Object.freeze({
-    module: tsp.ModuleKind.ESNext,
-    moduleResolution: tsp.ModuleResolutionKind.Node,
-    target: tsp.ScriptTarget.ES2020,
-    jsx: tsp.JsxEmit.React,
+const DEFAULT_PROJECT_CONFIG: ts.server.protocol.ExternalProjectCompilerOptions = Object.freeze({
+    module: ModuleKind.ESNext,
+    moduleResolution: ModuleResolutionKind.Node,
+    target: ScriptTarget.ES2020,
+    jsx: JsxEmit.React,
 });
 
 export function getInferredProjectCompilerOptions(
     workspaceConfig: WorkspaceConfigurationImplicitProjectConfigurationOptions,
-): tsp.ExternalProjectCompilerOptions {
+): ts.server.protocol.ExternalProjectCompilerOptions {
     const projectConfig = { ...DEFAULT_PROJECT_CONFIG };
 
     if (workspaceConfig.checkJs) {
@@ -41,11 +42,11 @@ export function getInferredProjectCompilerOptions(
     }
 
     if (workspaceConfig.module) {
-        projectConfig.module = workspaceConfig.module as tsp.ModuleKind;
+        projectConfig.module = workspaceConfig.module as ts.server.protocol.ModuleKind;
     }
 
     if (workspaceConfig.target) {
-        projectConfig.target = workspaceConfig.target as tsp.ScriptTarget;
+        projectConfig.target = workspaceConfig.target as ts.server.protocol.ScriptTarget;
     }
 
     projectConfig.sourceMap = true;

--- a/src/utils/typeConverters.ts
+++ b/src/utils/typeConverters.ts
@@ -6,22 +6,22 @@
  * Helpers for converting FROM LanguageServer types language-server ts types
  */
 import * as lsp from 'vscode-languageserver-protocol';
-import type { tsp } from '../ts-protocol.js';
+import type { ts } from '../ts-protocol.js';
 
 export namespace Range {
-    export const fromTextSpan = (span: tsp.TextSpan): lsp.Range => fromLocations(span.start, span.end);
+    export const fromTextSpan = (span: ts.server.protocol.TextSpan): lsp.Range => fromLocations(span.start, span.end);
 
-    export const toTextSpan = (range: lsp.Range): tsp.TextSpan => ({
+    export const toTextSpan = (range: lsp.Range): ts.server.protocol.TextSpan => ({
         start: Position.toLocation(range.start),
         end: Position.toLocation(range.end),
     });
 
-    export const fromLocations = (start: tsp.Location, end: tsp.Location): lsp.Range =>
+    export const fromLocations = (start: ts.server.protocol.Location, end: ts.server.protocol.Location): lsp.Range =>
         lsp.Range.create(
             Math.max(0, start.line - 1), Math.max(start.offset - 1, 0),
             Math.max(0, end.line - 1), Math.max(0, end.offset - 1));
 
-    export const toFileRangeRequestArgs = (file: string, range: lsp.Range): tsp.FileRangeRequestArgs => ({
+    export const toFileRangeRequestArgs = (file: string, range: lsp.Range): ts.server.protocol.FileRangeRequestArgs => ({
         file,
         startLine: range.start.line + 1,
         startOffset: range.start.character + 1,
@@ -29,7 +29,7 @@ export namespace Range {
         endOffset: range.end.character + 1,
     });
 
-    export const toFormattingRequestArgs = (file: string, range: lsp.Range): tsp.FormatRequestArgs => ({
+    export const toFormattingRequestArgs = (file: string, range: lsp.Range): ts.server.protocol.FormatRequestArgs => ({
         file,
         line: range.start.line + 1,
         offset: range.start.character + 1,
@@ -51,7 +51,7 @@ export namespace Range {
 }
 
 export namespace Position {
-    export const fromLocation = (tslocation: tsp.Location): lsp.Position => {
+    export const fromLocation = (tslocation: ts.server.protocol.Location): lsp.Position => {
         // Clamping on the low side to 0 since Typescript returns 0, 0 when creating new file
         // even though position is supposed to be 1-based.
         return {
@@ -60,12 +60,12 @@ export namespace Position {
         };
     };
 
-    export const toLocation = (position: lsp.Position): tsp.Location => ({
+    export const toLocation = (position: lsp.Position): ts.server.protocol.Location => ({
         line: position.line + 1,
         offset: position.character + 1,
     });
 
-    export const toFileLocationRequestArgs = (file: string, position: lsp.Position): tsp.FileLocationRequestArgs => ({
+    export const toFileLocationRequestArgs = (file: string, position: lsp.Position): ts.server.protocol.FileLocationRequestArgs => ({
         file,
         line: position.line + 1,
         offset: position.character + 1,
@@ -123,6 +123,6 @@ export namespace Position {
 }
 
 export namespace Location {
-    export const fromTextSpan = (resource: lsp.DocumentUri, tsTextSpan: tsp.TextSpan): lsp.Location =>
+    export const fromTextSpan = (resource: lsp.DocumentUri, tsTextSpan: ts.server.protocol.TextSpan): lsp.Location =>
         lsp.Location.create(resource, Range.fromTextSpan(tsTextSpan));
 }


### PR DESCRIPTION
Duplicate some enums and values from `tsserverlibrary.js` so that we don't depend on `typescript` dependency at runtime.

Fixes #658