### PR TITLE
feat: support for canceling LSP requests

### DIFF
--- a/src/features/inlay-hints.ts
+++ b/src/features/inlay-hints.ts
@@ -30,6 +30,7 @@ export class TypeScriptInlayHintsProvider {
         tspClient: TspClient,
         lspClient: LspClient,
         configurationManager: ConfigurationManager,
+        token?: lsp.CancellationToken,
     ): Promise<lsp.InlayHint[]> {
         if (tspClient.apiVersion.lt(TypeScriptInlayHintsProvider.minVersion)) {
             lspClient.showErrorMessage('Inlay Hints request failed. Requires TypeScript 4.4+.');
@@ -59,7 +60,7 @@ export class TypeScriptInlayHintsProvider {
         const start = document.offsetAt(range.start);
         const length = document.offsetAt(range.end) - start;
 
-        const response = await tspClient.request(CommandTypes.ProvideInlayHints, { file, start, length });
+        const response = await tspClient.request(CommandTypes.ProvideInlayHints, { file, start, length }, token);
         if (response.type !== 'response' || !response.success || !response.body) {
             return [];
         }

--- a/src/features/source-definition.ts
+++ b/src/features/source-definition.ts
@@ -29,6 +29,7 @@ export class SourceDefinitionCommand {
         tspClient: TspClient,
         lspClient: LspClient,
         reporter: lsp.WorkDoneProgressReporter,
+        token?: lsp.CancellationToken,
     ): Promise<lsp.Location[] | void> {
         if (tspClient.apiVersion.lt(SourceDefinitionCommand.minVersion)) {
             lspClient.showErrorMessage('Go to Source Definition failed. Requires TypeScript 4.7+.');
@@ -59,7 +60,7 @@ export class SourceDefinitionCommand {
             message: 'Finding source definitions…',
             reporter,
         }, async () => {
-            const response = await tspClient.request(CommandTypes.FindSourceDefinition, args);
+            const response = await tspClient.request(CommandTypes.FindSourceDefinition, args, token);
             if (response.type !== 'response' || !response.body) {
                 lspClient.showErrorMessage('No source definitions found.');
                 return;


### PR DESCRIPTION
Allows client to send `$/cancelRequest` request to cancel any previously triggered request. Previously that did nothing.

And related to that, cancel pending diagnostic request and re-request a new one on receiving document change notification.