### PR TITLE
feat: provide filterText property in completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-/lib/
-/node_modules/
-/.rollup.cache/
-.DS_Store
 *.log
 *.tsbuildinfo
+.DS_Store
+/.rollup.cache/
+/lib/
+node_modules/

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -159,7 +159,7 @@ function getRangeFromReplacementSpan(
         const range = ensureRangeIsOnSingleLine(optionalReplacementRange, document);
         return {
             insert: lsp.Range.create(range.start, position),
-            replace: ensureRangeIsOnSingleLine(range, document),
+            replace: range,
         };
     }
 }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -88,7 +88,7 @@ export function asCompletionItem(
     if (isMemberCompletion && dotAccessorContext && !entry.isSnippet) {
         item.filterText = dotAccessorContext.text + (insertText || entry.name);
         if (!range) {
-            range = { replacing: dotAccessorContext.range };
+            range = { replace: dotAccessorContext.range };
             insertText = item.filterText;
         }
     }
@@ -124,9 +124,9 @@ export function asCompletionItem(
     }
 
     if (range) {
-        item.textEdit = range.inserting
-            ? lsp.InsertReplaceEdit.create(insertText || item.label, range.inserting, range.replacing)
-            : lsp.TextEdit.replace(range.replacing, insertText || item.label);
+        item.textEdit = range.insert
+            ? lsp.InsertReplaceEdit.create(insertText || item.label, range.insert, range.replace)
+            : lsp.TextEdit.replace(range.replace, insertText || item.label);
     } else {
         item.insertText = insertText;
     }
@@ -175,18 +175,18 @@ function getRangeFromReplacementSpan(
     position: lsp.Position,
     document: LspDocument,
     features: SupportedFeatures,
-): { inserting?: lsp.Range; replacing: lsp.Range; } | undefined {
+): { insert?: lsp.Range; replace: lsp.Range; } | undefined {
     if (entry.replacementSpan) {
         // If TS provides an explicit replacement span with an entry, we should use it and not provide an insert.
         return {
-            replacing: ensureRangeIsOnSingleLine(Range.fromTextSpan(entry.replacementSpan), document),
+            replace: ensureRangeIsOnSingleLine(Range.fromTextSpan(entry.replacementSpan), document),
         };
     }
     if (features.completionInsertReplaceSupport && optionalReplacementRange) {
         const range = ensureRangeIsOnSingleLine(optionalReplacementRange, document);
         return {
-            inserting: lsp.Range.create(range.start, position),
-            replacing: ensureRangeIsOnSingleLine(range, document),
+            insert: lsp.Range.create(range.start, position),
+            replace: ensureRangeIsOnSingleLine(range, document),
         };
     }
 }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -24,7 +24,7 @@ interface ParameterListParts {
 }
 
 interface CompletionContext {
-    readonly isMemberCompletion?: boolean;
+    readonly isMemberCompletion: boolean;
     readonly dotAccessorContext?: {
         range: lsp.Range;
         text: string;

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -93,7 +93,7 @@ export function asCompletionItem(
             if (replacementRange) {
                 range = {
                     inserting: dotAccessorContext.range,
-                    replacing: rangeUnion(dotAccessorContext.range, replacementRange),
+                    replacing: Range.union(dotAccessorContext.range, replacementRange),
                 };
             } else {
                 range = dotAccessorContext.range;
@@ -505,10 +505,4 @@ export function getCompletionTriggerCharacter(character: string | undefined): ts
         default:
             return undefined;
     }
-}
-
-function rangeUnion(a: lsp.Range, b: lsp.Range): lsp.Range {
-    const start = a.start.line < b.start.line || a.start.line === b.start.line && a.start.character < b.start.character ? a.start : b.start;
-    const end = a.end.line > b.end.line || a.end.line === b.end.line && a.end.character > b.end.character ? a.end : b.end;
-    return { start, end };
 }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -29,9 +29,8 @@ interface CompletionContext {
         range: lsp.Range;
         text: string;
     };
-    readonly optionalReplacementSpan?: ts.server.protocol.TextSpan;
     line: string;
-    wordRange: lsp.Range | undefined;
+    optionalReplacementRange: lsp.Range | undefined;
 }
 
 export function asCompletionItem(
@@ -81,15 +80,15 @@ export function asCompletionItem(
     if (sourceDisplay) {
         item.detail = Previewer.plainWithLinks(sourceDisplay, filePathConverter);
     }
-    const { line, wordRange, isMemberCompletion, dotAccessorContext } = completionContext;
+    const { line, optionalReplacementRange, isMemberCompletion, dotAccessorContext } = completionContext;
     let range: lsp.Range | ReturnType<typeof getRangeFromReplacementSpan> = getRangeFromReplacementSpan(entry, document);
     item.insertText = entry.insertText;
-    item.filterText = getFilterText(entry, wordRange, line, item.insertText);
+    item.filterText = getFilterText(entry, optionalReplacementRange, line, item.insertText);
 
     if (isMemberCompletion && dotAccessorContext && !entry.isSnippet) {
         item.filterText = dotAccessorContext.text + (item.insertText || entry.name);
         if (!range) {
-            const replacementRange = wordRange;
+            const replacementRange = optionalReplacementRange;
             if (replacementRange) {
                 range = {
                     inserting: dotAccessorContext.range,
@@ -132,10 +131,10 @@ export function asCompletionItem(
         }
     }
 
-    if (!range && wordRange) {
+    if (!range && optionalReplacementRange) {
         range = {
-            inserting: lsp.Range.create(wordRange.start, position),
-            replacing: wordRange,
+            inserting: lsp.Range.create(optionalReplacementRange.start, position),
+            replacing: optionalReplacementRange,
         };
     }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -69,7 +69,7 @@ export function asCompletionItem(
         item.sortText = `\uffff${entry.sortText}`;
     }
 
-    const { isSnippet, sourceDisplay } = entry;
+    const { isSnippet, replacementSpan, sourceDisplay } = entry;
     if (isSnippet && !features.completionSnippets) {
         return null;
     }
@@ -80,8 +80,9 @@ export function asCompletionItem(
     if (sourceDisplay) {
         item.detail = Previewer.plainWithLinks(sourceDisplay, filePathConverter);
     }
+
     const { line, optionalReplacementRange, isMemberCompletion, dotAccessorContext } = completionContext;
-    let range = getRangeFromReplacementSpan(entry, optionalReplacementRange, position, document, features);
+    let range = getRangeFromReplacementSpan(replacementSpan, optionalReplacementRange, position, document, features);
     let { insertText } = entry;
     item.filterText = getFilterText(entry, optionalReplacementRange, line, insertText);
 
@@ -170,16 +171,16 @@ function getFilterText(entry: ts.server.protocol.CompletionEntry, wordRange: lsp
 }
 
 function getRangeFromReplacementSpan(
-    entry: ts.server.protocol.CompletionEntry,
+    replacementSpan: ts.server.protocol.TextSpan | undefined,
     optionalReplacementRange: lsp.Range | undefined,
     position: lsp.Position,
     document: LspDocument,
     features: SupportedFeatures,
 ): { insert?: lsp.Range; replace: lsp.Range; } | undefined {
-    if (entry.replacementSpan) {
+    if (replacementSpan) {
         // If TS provides an explicit replacement span with an entry, we should use it and not provide an insert.
         return {
-            replace: ensureRangeIsOnSingleLine(Range.fromTextSpan(entry.replacementSpan), document),
+            replace: ensureRangeIsOnSingleLine(Range.fromTextSpan(replacementSpan), document),
         };
     }
     if (features.completionInsertReplaceSupport && optionalReplacementRange) {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -89,7 +89,14 @@ export function asCompletionItem(
     if (isMemberCompletion && dotAccessorContext && !entry.isSnippet) {
         item.filterText = dotAccessorContext.text + (insertText || entry.name);
         if (!range) {
-            range = { replace: dotAccessorContext.range };
+            if (features.completionInsertReplaceSupport && optionalReplacementRange) {
+                range = {
+                    insert: dotAccessorContext.range,
+                    replace: Range.union(dotAccessorContext.range, optionalReplacementRange),
+                };
+            } else {
+                range = { replace: dotAccessorContext.range };
+            }
             insertText = item.filterText;
         }
     }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -23,14 +23,14 @@ interface ParameterListParts {
     readonly hasOptionalParameters: boolean;
 }
 
-interface CompletionContext {
+export interface CompletionContext {
     readonly isMemberCompletion: boolean;
     readonly dotAccessorContext?: {
         range: lsp.Range;
         text: string;
     };
-    line: string;
-    optionalReplacementRange: lsp.Range | undefined;
+    readonly line: string;
+    readonly optionalReplacementRange: lsp.Range | undefined;
 }
 
 export function asCompletionItem(

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -87,7 +87,7 @@ export function asCompletionItem(
     item.filterText = getFilterText(entry, optionalReplacementRange, line, insertText);
 
     if (isMemberCompletion && dotAccessorContext && !entry.isSnippet) {
-        item.filterText = dotAccessorContext.text + (insertText || entry.name);
+        item.filterText = dotAccessorContext.text + (insertText || item.label);
         if (!range) {
             if (features.completionInsertReplaceSupport && optionalReplacementRange) {
                 range = {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -88,11 +88,10 @@ export function asCompletionItem(
     if (isMemberCompletion && dotAccessorContext && !entry.isSnippet) {
         item.filterText = dotAccessorContext.text + (insertText || entry.name);
         if (!range) {
-            const replacementRange = optionalReplacementRange;
-            if (replacementRange) {
+            if (optionalReplacementRange) {
                 range = {
                     inserting: dotAccessorContext.range,
-                    replacing: Range.union(dotAccessorContext.range, replacementRange),
+                    replacing: Range.union(dotAccessorContext.range, optionalReplacementRange),
                 };
             } else {
                 range = dotAccessorContext.range;

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -274,19 +274,7 @@ describe('completion', () => {
         expect(proposals).not.toBeNull();
         const completion = proposals!.items.find(completion => completion.label === 'getById');
         expect(completion).toBeDefined();
-        expect(completion!.textEdit).toMatchObject({
-            newText: 'getById',
-            range: {
-                start: {
-                    character: 20,
-                    line: 6,
-                },
-                end: {
-                    character: 23,
-                    line: 6,
-                },
-            },
-        });
+        expect(completion!.textEdit).toBeUndefined();
         localServer.didCloseTextDocument({ textDocument: doc });
         localServer.closeAll();
         localServer.shutdown();

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -311,17 +311,7 @@ describe('completion', () => {
             detail: 'fs',
             textEdit: {
                 newText: 'import { readFile$1 } from "fs";',
-                insert: {
-                    start: {
-                        line: 0,
-                        character: 0,
-                    },
-                    end: {
-                        line: 0,
-                        character: 19,
-                    },
-                },
-                replace: {
+                range: {
                     start: {
                         line: 0,
                         character: 0,
@@ -673,17 +663,7 @@ describe('completion', () => {
             label: 'fs/read',
             textEdit: {
                 newText: 'fs/read',
-                insert: {
-                    start: {
-                        line: 5,
-                        character: 20,
-                    },
-                    end: {
-                        line: 5,
-                        character: 24,
-                    },
-                },
-                replace: {
+                range: {
                     start: {
                         line: 5,
                         character: 20,

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -274,7 +274,19 @@ describe('completion', () => {
         expect(proposals).not.toBeNull();
         const completion = proposals!.items.find(completion => completion.label === 'getById');
         expect(completion).toBeDefined();
-        expect(completion!.textEdit).toBeUndefined();
+        expect(completion!.textEdit).toMatchObject({
+            newText: 'getById',
+            range: {
+                start: {
+                    character: 20,
+                    line: 6,
+                },
+                end: {
+                    character: 23,
+                    line: 6,
+                },
+            },
+        });
         localServer.didCloseTextDocument({ textDocument: doc });
         localServer.closeAll();
         localServer.shutdown();
@@ -299,7 +311,17 @@ describe('completion', () => {
             detail: 'fs',
             textEdit: {
                 newText: 'import { readFile$1 } from "fs";',
-                range: {
+                insert: {
+                    start: {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: {
+                        line: 0,
+                        character: 19,
+                    },
+                },
+                replace: {
                     start: {
                         line: 0,
                         character: 0,
@@ -651,7 +673,17 @@ describe('completion', () => {
             label: 'fs/read',
             textEdit: {
                 newText: 'fs/read',
-                range: {
+                insert: {
+                    start: {
+                        line: 5,
+                        character: 20,
+                    },
+                    end: {
+                        line: 5,
+                        character: 24,
+                    },
+                },
+                replace: {
                     start: {
                         line: 5,
                         character: 20,

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -626,9 +626,9 @@ export class LspServer {
                 return lsp.CompletionList.create();
             }
             const { entries, isIncomplete, optionalReplacementSpan, isMemberCompletion } = body;
+            const line = document.getLine(params.position.line);
             let dotAccessorContext: { range: lsp.Range; text: string; } | undefined;
             if (isMemberCompletion) {
-                const line = document.getLine(params.position.line);
                 const dotMatch = line.slice(0, params.position.character).match(/\??\.\s*$/) || undefined;
                 if (dotMatch) {
                     const startPosition = lsp.Position.create(params.position.line, params.position.character - dotMatch[0].length);
@@ -643,7 +643,7 @@ export class LspServer {
             const completionContext: CompletionContext = {
                 isMemberCompletion,
                 dotAccessorContext,
-                line: document.getLine(params.position.line),
+                line,
                 optionalReplacementRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
             };
             const completions: lsp.CompletionItem[] = [];

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -15,7 +15,7 @@ import { TspClient } from './tsp-client.js';
 import { DiagnosticEventQueue } from './diagnostic-queue.js';
 import { toDocumentHighlight, uriToPath, toSymbolKind, toLocation, toSelectionRange, pathToUri, toTextEdit, normalizePath } from './protocol-translation.js';
 import { LspDocuments, LspDocument } from './document.js';
-import { asCompletionItem, asResolvedCompletionItem, getCompletionTriggerCharacter } from './completion.js';
+import { asCompletionItem, asResolvedCompletionItem, CompletionContext, getCompletionTriggerCharacter } from './completion.js';
 import { asSignatureHelp, toTsTriggerReason } from './hover.js';
 import { Commands, TypescriptVersionNotification } from './commands.js';
 import { provideQuickFix } from './quickfix.js';
@@ -640,17 +640,18 @@ export class LspServer {
                     };
                 }
             }
+            const completionContext: CompletionContext = {
+                isMemberCompletion,
+                dotAccessorContext,
+                line: document.getLine(params.position.line),
+                optionalReplacementRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
+            };
             const completions: lsp.CompletionItem[] = [];
             for (const entry of entries || []) {
                 if (entry.kind === 'warning') {
                     continue;
                 }
-                const completion = asCompletionItem(entry, file, params.position, document, this.documents, completionOptions, this.features, {
-                    isMemberCompletion,
-                    dotAccessorContext,
-                    line: document.getLine(params.position.line),
-                    optionalReplacementRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
-                });
+                const completion = asCompletionItem(entry, file, params.position, document, this.documents, completionOptions, this.features, completionContext);
                 if (!completion) {
                     continue;
                 }

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -627,17 +627,14 @@ export class LspServer {
             }
             const { entries, isIncomplete, optionalReplacementSpan, isMemberCompletion } = body;
             const line = document.getLine(params.position.line);
-            let dotAccessorContext: { range: lsp.Range; text: string; } | undefined;
+            let dotAccessorContext: CompletionContext['dotAccessorContext'];
             if (isMemberCompletion) {
                 const dotMatch = line.slice(0, params.position.character).match(/\??\.\s*$/) || undefined;
                 if (dotMatch) {
                     const startPosition = lsp.Position.create(params.position.line, params.position.character - dotMatch[0].length);
                     const range = lsp.Range.create(startPosition, params.position);
                     const text = document.getText(range);
-                    dotAccessorContext = {
-                        range,
-                        text,
-                    };
+                    dotAccessorContext = { range, text };
                 }
             }
             const completionContext: CompletionContext = {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -648,9 +648,8 @@ export class LspServer {
                 const completion = asCompletionItem(entry, file, params.position, document, this.documents, completionOptions, this.features, {
                     isMemberCompletion,
                     dotAccessorContext,
-                    optionalReplacementSpan,
                     line: document.getLine(params.position.line),
-                    wordRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
+                    optionalReplacementRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
                 });
                 if (!completion) {
                     continue;

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -649,6 +649,8 @@ export class LspServer {
                     isMemberCompletion,
                     dotAccessorContext,
                     optionalReplacementSpan,
+                    line: document.getLine(params.position.line),
+                    wordRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
                 });
                 if (!completion) {
                     continue;

--- a/src/utils/typeConverters.ts
+++ b/src/utils/typeConverters.ts
@@ -48,6 +48,12 @@ export namespace Range {
         }
         return lsp.Range.create(start, end);
     }
+
+    export function union(one: lsp.Range, other: lsp.Range): lsp.Range {
+        const start = Position.Min(other.start, one.start);
+        const end = Position.Max(other.end, one.end);
+        return lsp.Range.create(start, end);
+    }
 }
 
 export namespace Position {


### PR DESCRIPTION
fix(#631)
The implementation method refers to the implementation of vscode and volar:

vscode: https://github.com/microsoft/vscode/blob/6c866f92d7646c31bd9286b1cd8b8151c1e5b38e/extensions/typescript-language-features/src/languageFeatures/completions.ts#L100
volar(vue): https://github.com/volarjs/plugins/blob/master/packages/typescript/src/services/completions/basic.ts