### PR TITLE
feat: support `workspace/willRenameFiles` request

### DIFF
--- a/src/lsp-connection.ts
+++ b/src/lsp-connection.ts
@@ -62,6 +62,7 @@ export function createLspConnection(options: LspConnectionOptions): lsp.Connecti
     connection.languages.inlayHint.on(server.inlayHints.bind(server));
     connection.languages.semanticTokens.on(server.semanticTokensFull.bind(server));
     connection.languages.semanticTokens.onRange(server.semanticTokensRange.bind(server));
+    connection.workspace.onWillRenameFiles(server.willRenameFiles.bind(server));
 
     return connection;
 }

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -2190,11 +2190,16 @@ describe('fileOperations', () => {
         const edit = await server.willRenameFiles({
             files: [{ oldUri: uri('module1.ts'), newUri: uri('new_module1_name.ts') }],
         });
-        expect(edit.changes).not.toBeNull();
-        expect((edit?.changes || {})[uri('module2.ts')]).toEqual([{ range: {
-            start:{ line:0, character:25 },
-            end: { line:0, character:34 } },
-        newText:'./new_module1_name',
-        }]);
+        expect(edit.changes).toBeDefined();
+        expect(Object.keys(edit.changes!)).toHaveLength(1);
+        expect(edit.changes![uri('module2.ts')]).toEqual([
+            {
+                range: {
+                    start:{ line: 0, character: 25 },
+                    end: { line: 0, character: 34 },
+                },
+                newText:'./new_module1_name',
+            },
+        ]);
     });
 });

--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -2184,3 +2184,17 @@ describe('completions without client snippet support', () => {
         );
     });
 });
+
+describe('fileOperations', () => {
+    it('willRenameFiles', async () => {
+        const edit = await server.willRenameFiles({
+            files: [{ oldUri: uri('module1.ts'), newUri: uri('new_module1_name.ts') }],
+        });
+        expect(edit.changes).not.toBeNull();
+        expect((edit?.changes || {})[uri('module2.ts')]).toEqual([{ range: {
+            start:{ line:0, character:25 },
+            end: { line:0, character:34 } },
+        newText:'./new_module1_name',
+        }]);
+    });
+});

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -261,7 +261,7 @@ export class LspServer {
                         willRename: {
                             filters: [{
                                 scheme: 'file',
-                                pattern: { glob: '**/*.{ts,js,jsx,tsx,mjs,mts,cjs}', matches: 'file' },
+                                pattern: { glob: '**/*.{ts,js,jsx,tsx,mjs,mts,cjs,cts}', matches: 'file' },
                             }],
                         },
                     },


### PR DESCRIPTION
Hey! I've been working on a plugin for neovim that automatically applies workspace edits before moving files around. And it does not work with typescript. The problem with `_typescript.applyRenameFile` that edit is applied only after neovim moves the file. 

So I wanted to implement `workspase/willRenameFile` command that returns the edit. We will be then able to preview and apply it if needed.

Closes https://github.com/typescript-language-server/typescript-language-server/issues/665
Closes https://github.com/antosha417/nvim-lsp-file-operations/issues/6