### PR TITLE
feat: start separate tsServer instance for semantic requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ interface TsserverOptions {
      * @default 'off'
      */
     trace?: 'off' | 'messages' | 'verbose';
+    /**
+     * Controls if TypeScript launches a dedicated server to more quickly handle syntax related operations, such as computing diagnostics or code folding.
+     *
+     * Allowed values:
+     *  - auto: Spawn both a full server and a lighter weight server dedicated to syntax operations. The syntax server is used to speed up syntax operations and provide IntelliSense while projects are loading.
+     *  - never: Don't use a dedicated syntax server. Use a single server to handle all IntelliSense operations.
+     *
+     * @default 'auto'
+     */
+    useSyntaxServer?: 'auto' | 'never';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ interface TsserverOptions {
      */
     trace?: 'off' | 'messages' | 'verbose';
     /**
-     * Controls if TypeScript launches a dedicated server to more quickly handle syntax related operations, such as computing diagnostics or code folding.
+     * Whether a dedicated server is launched to more quickly handle syntax related operations, such as computing diagnostics or code folding.
      *
      * Allowed values:
      *  - auto: Spawn both a full server and a lighter weight server dedicated to syntax operations. The syntax server is used to speed up syntax operations and provide IntelliSense while projects are loading.

--- a/src/configuration-manager.ts
+++ b/src/configuration-manager.ts
@@ -128,7 +128,7 @@ export class ConfigurationManager {
                 autoImportFileExcludePatterns: this.getAutoImportFileExcludePatternsPreference(workspaceFolder),
             },
         };
-        client.executeWithoutWaitingForResponse(CommandTypes.Configure, args);
+        client.request(CommandTypes.Configure, args);
     }
 
     public async configureGloballyFromDocument(filename: string, formattingOptions?: lsp.FormattingOptions): Promise<void> {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -11,7 +11,7 @@ import debounce from 'p-debounce';
 import * as lsp from 'vscode-languageserver';
 import API from './utils/api.js';
 import { Logger, LogLevel, PrefixingLogger } from './utils/logger.js';
-import { TspClient } from './tsp-client.js';
+import { getDignosticsKind, TspClient } from './tsp-client.js';
 import { DiagnosticEventQueue } from './diagnostic-queue.js';
 import { toDocumentHighlight, uriToPath, toSymbolKind, toLocation, toSelectionRange, pathToUri, toTextEdit, normalizePath } from './protocol-translation.js';
 import { LspDocuments, LspDocument } from './document.js';
@@ -21,10 +21,10 @@ import { Commands, TypescriptVersionNotification } from './commands.js';
 import { provideQuickFix } from './quickfix.js';
 import { provideRefactors } from './refactor.js';
 import { organizeImportsCommands, provideOrganizeImports } from './organize-imports.js';
-import { CommandTypes, EventTypes, OrganizeImportsMode, TypeScriptInitializeParams, TypeScriptInitializationOptions, SupportedFeatures } from './ts-protocol.js';
+import { CommandTypes, EventName, OrganizeImportsMode, TypeScriptInitializeParams, TypeScriptInitializationOptions, SupportedFeatures } from './ts-protocol.js';
 import type { ts } from './ts-protocol.js';
 import { collectDocumentSymbols, collectSymbolInformation } from './document-symbol.js';
-import { TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration.js';
+import { toSyntaxServerConfiguration, TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration.js';
 import { fromProtocolCallHierarchyItem, fromProtocolCallHierarchyIncomingCall, fromProtocolCallHierarchyOutgoingCall } from './features/call-hierarchy.js';
 import { TypeScriptAutoFixProvider } from './features/fix-all.js';
 import { TypeScriptInlayHintsProvider } from './features/inlay-hints.js';
@@ -140,12 +140,6 @@ export class LspServer {
             useLabelDetailsInCompletionEntries: this.features.completionLabelDetails,
         });
 
-        this.diagnosticQueue = new DiagnosticEventQueue(
-            diagnostics => this.options.lspClient.publishDiagnostics(diagnostics),
-            this.documents,
-            this.features,
-            this.logger,
-        );
         const tsserverLogVerbosity = tsserver?.logVerbosity && TsServerLogLevel.fromString(tsserver?.logVerbosity);
         this._tspClient = new TspClient({
             lspClient: this.options.lspClient,
@@ -167,7 +161,16 @@ export class LspServer {
                     throw new Error(`tsserver process has exited (exit code: ${exitCode}, signal: ${signal}). Stopping the server.`);
                 }
             },
+            useSyntaxServer: toSyntaxServerConfiguration(userInitializationOptions.tsserver?.useSyntaxServer),
         });
+
+        this.diagnosticQueue = new DiagnosticEventQueue(
+            diagnostics => this.options.lspClient.publishDiagnostics(diagnostics),
+            this.documents,
+            this.features,
+            this.logger,
+            this._tspClient,
+        );
 
         const started = this.tspClient.start();
         if (!started) {
@@ -585,19 +588,18 @@ export class LspServer {
         }
 
         const response = await this.tspClient.request(CommandTypes.NavTree, { file }, token);
-        const tree = response.body;
-        if (!tree?.childItems) {
+        if (response.type !== 'response' || !response.body?.childItems) {
             return [];
         }
         if (this.supportHierarchicalDocumentSymbol) {
             const symbols: lsp.DocumentSymbol[] = [];
-            for (const item of tree.childItems) {
+            for (const item of response.body.childItems) {
                 collectDocumentSymbols(item, symbols);
             }
             return symbols;
         }
         const symbols: lsp.SymbolInformation[] = [];
-        for (const item of tree.childItems) {
+        for (const item of response.body.childItems) {
             collectSymbolInformation(params.textDocument.uri, item, symbols);
         }
         return symbols;
@@ -626,71 +628,60 @@ export class LspServer {
 
         const completionOptions = this.configurationManager.workspaceConfiguration.completions || {};
 
-        try {
-            const result = await this.interuptDiagnostics(() => this.tspClient.request(
-                CommandTypes.CompletionInfo,
-                {
-                    file,
-                    line: params.position.line + 1,
-                    offset: params.position.character + 1,
-                    triggerCharacter: getCompletionTriggerCharacter(params.context?.triggerCharacter),
-                    triggerKind: params.context?.triggerKind,
-                },
-                token));
-            const { body } = result;
-            if (!body) {
-                return lsp.CompletionList.create();
-            }
-            const { entries, isIncomplete, optionalReplacementSpan, isMemberCompletion } = body;
-            const line = document.getLine(params.position.line);
-            let dotAccessorContext: CompletionContext['dotAccessorContext'];
-            if (isMemberCompletion) {
-                const dotMatch = line.slice(0, params.position.character).match(/\??\.\s*$/) || undefined;
-                if (dotMatch) {
-                    const startPosition = lsp.Position.create(params.position.line, params.position.character - dotMatch[0].length);
-                    const range = lsp.Range.create(startPosition, params.position);
-                    const text = document.getText(range);
-                    dotAccessorContext = { range, text };
-                }
-            }
-            const completionContext: CompletionContext = {
-                isMemberCompletion,
-                dotAccessorContext,
-                line,
-                optionalReplacementRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
-            };
-            const completions: lsp.CompletionItem[] = [];
-            for (const entry of entries || []) {
-                if (entry.kind === 'warning') {
-                    continue;
-                }
-                const completion = asCompletionItem(entry, file, params.position, document, this.documents, completionOptions, this.features, completionContext);
-                if (!completion) {
-                    continue;
-                }
-                completions.push(completion);
-            }
-            return lsp.CompletionList.create(completions, isIncomplete);
-        } catch (error) {
-            if ((error as Error).message === 'No content available.') {
-                this.logger.info('No content was available for completion request');
-                return null;
-            } else {
-                throw error;
+        const response = await this.interuptDiagnostics(() => this.tspClient.request(
+            CommandTypes.CompletionInfo,
+            {
+                file,
+                line: params.position.line + 1,
+                offset: params.position.character + 1,
+                triggerCharacter: getCompletionTriggerCharacter(params.context?.triggerCharacter),
+                triggerKind: params.context?.triggerKind,
+            },
+            token));
+        if (response.type !== 'response' || !response.body) {
+            return lsp.CompletionList.create();
+        }
+        const { entries, isIncomplete, optionalReplacementSpan, isMemberCompletion } = response.body;
+        const line = document.getLine(params.position.line);
+        let dotAccessorContext: CompletionContext['dotAccessorContext'];
+        if (isMemberCompletion) {
+            const dotMatch = line.slice(0, params.position.character).match(/\??\.\s*$/) || undefined;
+            if (dotMatch) {
+                const startPosition = lsp.Position.create(params.position.line, params.position.character - dotMatch[0].length);
+                const range = lsp.Range.create(startPosition, params.position);
+                const text = document.getText(range);
+                dotAccessorContext = { range, text };
             }
         }
+        const completionContext: CompletionContext = {
+            isMemberCompletion,
+            dotAccessorContext,
+            line,
+            optionalReplacementRange: optionalReplacementSpan ? Range.fromTextSpan(optionalReplacementSpan) : undefined,
+        };
+        const completions: lsp.CompletionItem[] = [];
+        for (const entry of entries || []) {
+            if (entry.kind === 'warning') {
+                continue;
+            }
+            const completion = asCompletionItem(entry, file, params.position, document, this.documents, completionOptions, this.features, completionContext);
+            if (!completion) {
+                continue;
+            }
+            completions.push(completion);
+        }
+        return lsp.CompletionList.create(completions, isIncomplete);
     }
 
     async completionResolve(item: lsp.CompletionItem, token?: lsp.CancellationToken): Promise<lsp.CompletionItem> {
         this.logger.log('completion/resolve', item);
         const document = item.data?.file ? this.documents.get(item.data.file) : undefined;
         await this.configurationManager.configureGloballyFromDocument(item.data.file);
-        const { body } = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionDetails, item.data, token));
-        const details = body?.length && body[0];
-        if (!details) {
+        const response = await this.interuptDiagnostics(() => this.tspClient.request(CommandTypes.CompletionDetails, item.data, token));
+        if (response.type !== 'response' || !response.body?.length) {
             return item;
         }
-        return asResolvedCompletionItem(item, details, document, this.tspClient, this.documents, this.configurationManager.workspaceConfiguration.completions || {}, this.features);
+        return asResolvedCompletionItem(item, response.body[0], document, this.tspClient, this.documents, this.configurationManager.workspaceConfiguration.completions || {}, this.features);
     }
 
     async hover(params: lsp.TextDocumentPositionParams, token?: lsp.CancellationToken): Promise<lsp.Hover> {
@@ -716,18 +707,17 @@ export class LspServer {
         };
     }
     protected async getQuickInfo(file: string, position: lsp.Position, token?: lsp.CancellationToken): Promise<ts.server.protocol.QuickInfoResponse | undefined> {
-        try {
-            return await this.tspClient.request(
-                CommandTypes.Quickinfo,
-                {
-                    file,
-                    line: position.line + 1,
-                    offset: position.character + 1,
-                },
-                token,
-            );
-        } catch (err) {
-            return undefined;
+        const response = await this.tspClient.request(
+            CommandTypes.Quickinfo,
+            {
+                file,
+                line: position.line + 1,
+                offset: position.character + 1,
+            },
+            token,
+        );
+        if (response.type === 'response') {
+            return response;
         }
     }
 
@@ -736,11 +726,11 @@ export class LspServer {
         if (!file) {
             return null;
         }
-        const result = await this.tspClient.request(CommandTypes.Rename, Position.toFileLocationRequestArgs(file, params.position), token);
-        const renameInfo = result.body?.info;
-        if (!renameInfo) {
+        const response = await this.tspClient.request(CommandTypes.Rename, Position.toFileLocationRequestArgs(file, params.position), token);
+        if (response.type !== 'response' || !response.body?.info) {
             return null;
         }
+        const renameInfo = response.body.info;
         if (!renameInfo.canRename) {
             throw new Error(renameInfo.localizedErrorMessage);
         }
@@ -753,12 +743,15 @@ export class LspServer {
         if (!file) {
             return null;
         }
-        const result = await this.tspClient.request(CommandTypes.Rename, Position.toFileLocationRequestArgs(file, params.position), token);
-        if (!result.body?.info.canRename || result.body.locs.length === 0) {
+        const response = await this.interuptDiagnostics(async () => {
+            await this.configurationManager.configureGloballyFromDocument(file);
+            return await this.tspClient.request(CommandTypes.Rename, Position.toFileLocationRequestArgs(file, params.position), token);
+        });
+        if (response.type !== 'response' || !response.body?.info.canRename || !response.body?.locs.length) {
             return null;
         }
         const changes: lsp.WorkspaceEdit['changes'] = {};
-        result.body.locs
+        response.body.locs
             .forEach((spanGroup) => {
                 const uri = pathToUri(spanGroup.file, this.documents);
                 const textEdits = changes[uri] || (changes[uri] = []);
@@ -784,7 +777,7 @@ export class LspServer {
             return [];
         }
 
-        const result = await this.tspClient.request(
+        const response = await this.tspClient.request(
             CommandTypes.References,
             {
                 file,
@@ -793,10 +786,10 @@ export class LspServer {
             },
             token,
         );
-        if (!result.body) {
+        if (response.type !== 'response' || !response.body) {
             return [];
         }
-        return result.body.refs
+        return response.body.refs
             .filter(fileSpan => params.context.includeDeclaration || !fileSpan.isDefinition)
             .map(fileSpan => toLocation(fileSpan, this.documents));
     }
@@ -823,10 +816,10 @@ export class LspServer {
             },
             token,
         );
-        if (response.body) {
-            return response.body.map(e => toTextEdit(e));
+        if (response.type !== 'response' || !response.body) {
+            return [];
         }
-        return [];
+        return response.body.map(e => toTextEdit(e));
     }
 
     async documentRangeFormatting(params: lsp.DocumentRangeFormattingParams, token?: lsp.CancellationToken): Promise<lsp.TextEdit[]> {
@@ -851,10 +844,10 @@ export class LspServer {
             },
             token,
         );
-        if (response.body) {
-            return response.body.map(e => toTextEdit(e));
+        if (response.type !== 'response' || !response.body) {
+            return [];
         }
-        return [];
+        return response.body.map(e => toTextEdit(e));
     }
 
     async selectionRanges(params: lsp.SelectionRangeParams, token?: lsp.CancellationToken): Promise<lsp.SelectionRange[] | null> {
@@ -890,20 +883,19 @@ export class LspServer {
         return asSignatureHelp(response.body, params.context, this.documents);
     }
     protected async getSignatureHelp(file: string, params: lsp.SignatureHelpParams, token?: lsp.CancellationToken): Promise<ts.server.protocol.SignatureHelpResponse | undefined> {
-        try {
-            const { position, context } = params;
-            return await this.tspClient.request(
-                CommandTypes.SignatureHelp,
-                {
-                    file,
-                    line: position.line + 1,
-                    offset: position.character + 1,
-                    triggerReason: context ? toTsTriggerReason(context) : undefined,
-                },
-                token,
-            );
-        } catch (err) {
-            return undefined;
+        const { position, context } = params;
+        const response = await this.tspClient.request(
+            CommandTypes.SignatureHelp,
+            {
+                file,
+                line: position.line + 1,
+                offset: position.character + 1,
+                triggerReason: context ? toTsTriggerReason(context) : undefined,
+            },
+            token,
+        );
+        if (response.type === 'response') {
+            return response;
         }
     }
 
@@ -938,7 +930,7 @@ export class LspServer {
                     skipDestructiveCodeActions = documentHasErrors;
                     mode = OrganizeImportsMode.SortAndCombine;
                 }
-                const response = await this.tspClient.request(
+                const response = await this.interuptDiagnostics(() => this.tspClient.request(
                     CommandTypes.OrganizeImports,
                     {
                         scope: { type: 'file', args: fileRangeArgs },
@@ -946,8 +938,10 @@ export class LspServer {
                         skipDestructiveCodeActions,
                         mode,
                     },
-                    token);
-                actions.push(...provideOrganizeImports(command, response, this.documents));
+                    token));
+                if (response.type === 'response' && response.body) {
+                    actions.push(...provideOrganizeImports(command, response, this.documents));
+                }
             }
         }
 
@@ -965,17 +959,14 @@ export class LspServer {
 
         return actions;
     }
-    protected async getCodeFixes(fileRangeArgs: ts.server.protocol.FileRangeRequestArgs, context: lsp.CodeActionContext, token?: lsp.CancellationToken): Promise<ts.server.protocol.GetCodeFixesResponse | undefined> {
+    protected async getCodeFixes(fileRangeArgs: ts.server.protocol.FileRangeRequestArgs, context: lsp.CodeActionContext, token?: lsp.CancellationToken): Promise<ts.server.protocol.CodeFixResponse | undefined> {
         const errorCodes = context.diagnostics.map(diagnostic => Number(diagnostic.code));
         const args: ts.server.protocol.CodeFixRequestArgs = {
             ...fileRangeArgs,
             errorCodes,
         };
-        try {
-            return await this.tspClient.request(CommandTypes.GetCodeFixes, args, token);
-        } catch (err) {
-            return undefined;
-        }
+        const response = await this.tspClient.request(CommandTypes.GetCodeFixes, args, token);
+        return response.type === 'response' ? response : undefined;
     }
     protected async getRefactors(fileRangeArgs: ts.server.protocol.FileRangeRequestArgs, context: lsp.CodeActionContext, token?: lsp.CancellationToken): Promise<ts.server.protocol.GetApplicableRefactorsResponse | undefined> {
         const args: ts.server.protocol.GetApplicableRefactorsRequestArgs = {
@@ -983,11 +974,8 @@ export class LspServer {
             triggerReason: context.triggerKind === lsp.CodeActionTriggerKind.Invoked ? 'invoked' : undefined,
             kind: context.only?.length === 1 ? context.only[0] : undefined,
         };
-        try {
-            return await this.tspClient.request(CommandTypes.GetApplicableRefactors, args, token);
-        } catch (err) {
-            return undefined;
-        }
+        const response = await this.tspClient.request(CommandTypes.GetApplicableRefactors, args, token);
+        return response.type === 'response' ? response : undefined;
     }
 
     async executeCommand(arg: lsp.ExecuteCommandParams, token?: lsp.CancellationToken, workDoneProgress?: lsp.WorkDoneProgressReporter): Promise<any> {
@@ -1007,7 +995,11 @@ export class LspServer {
             }
         } else if (arg.command === Commands.APPLY_REFACTORING && arg.arguments) {
             const args = arg.arguments[0] as ts.server.protocol.GetEditsForRefactorRequestArgs;
-            const { body } = await this.tspClient.request(CommandTypes.GetEditsForRefactor, args, token);
+            const response = await this.tspClient.request(CommandTypes.GetEditsForRefactor, args, token);
+            if (response.type !== 'response' || !response.body) {
+                return;
+            }
+            const { body } = response;
             if (!body?.edits.length) {
                 return;
             }
@@ -1042,7 +1034,7 @@ export class LspServer {
             const file = arg.arguments[0] as string;
             const additionalArguments: { skipDestructiveCodeActions?: boolean; } = arg.arguments[1] || {};
             await this.configurationManager.configureGloballyFromDocument(file);
-            const { body } = await this.tspClient.request(
+            const response = await this.tspClient.request(
                 CommandTypes.OrganizeImports,
                 {
                     scope: {
@@ -1053,6 +1045,10 @@ export class LspServer {
                 },
                 token,
             );
+            if (response.type !== 'response' || !response.body) {
+                return;
+            }
+            const { body } = response;
             await this.applyFileCodeEdits(body);
         } else if (arg.command === Commands.APPLY_RENAME_FILE && arg.arguments) {
             const { sourceUri, targetUri } = arg.arguments[0] as {
@@ -1118,19 +1114,18 @@ export class LspServer {
         if (!newFilePath || !oldFilePath) {
             return [];
         }
-        try {
-            const { body } = await this.tspClient.request(
-                CommandTypes.GetEditsForFileRename,
-                {
-                    oldFilePath,
-                    newFilePath,
-                },
-                token,
-            );
-            return body;
-        } catch (err) {
+        const response = await this.tspClient.request(
+            CommandTypes.GetEditsForFileRename,
+            {
+                oldFilePath,
+                newFilePath,
+            },
+            token,
+        );
+        if (response.type !== 'response' || !response.body) {
             return [];
         }
+        return response.body;
     }
 
     async documentHighlight(arg: lsp.TextDocumentPositionParams, token?: lsp.CancellationToken): Promise<lsp.DocumentHighlight[]> {
@@ -1139,22 +1134,17 @@ export class LspServer {
         if (!file) {
             return [];
         }
-        let response: ts.server.protocol.DocumentHighlightsResponse;
-        try {
-            response = await this.tspClient.request(
-                CommandTypes.DocumentHighlights,
-                {
-                    file,
-                    line: arg.position.line + 1,
-                    offset: arg.position.character + 1,
-                    filesToSearch: [file],
-                },
-                token,
-            );
-        } catch (err) {
-            return [];
-        }
-        if (!response.body) {
+        const response = await this.tspClient.request(
+            CommandTypes.DocumentHighlights,
+            {
+                file,
+                line: arg.position.line + 1,
+                offset: arg.position.character + 1,
+                filesToSearch: [file],
+            },
+            token,
+        );
+        if (response.type !== 'response' || !response.body) {
             return [];
         }
         const result: lsp.DocumentHighlight[] = [];
@@ -1174,7 +1164,7 @@ export class LspServer {
     }
 
     async workspaceSymbol(params: lsp.WorkspaceSymbolParams, token?: lsp.CancellationToken): Promise<lsp.SymbolInformation[]> {
-        const result = await this.tspClient.request(
+        const response = await this.tspClient.request(
             CommandTypes.Navto,
             {
                 file: this.lastFileOrDummy(),
@@ -1182,10 +1172,10 @@ export class LspServer {
             },
             token,
         );
-        if (!result.body) {
+        if (response.type !== 'response' || !response.body) {
             return [];
         }
-        return result.body.map(item => {
+        return response.body.map(item => {
             return <lsp.SymbolInformation>{
                 location: {
                     uri: pathToUri(item.file, this.documents),
@@ -1214,12 +1204,12 @@ export class LspServer {
         if (!document) {
             throw new Error(`The document should be opened for foldingRanges', file: ${file}`);
         }
-        const { body } = await this.tspClient.request(CommandTypes.GetOutliningSpans, { file }, token);
-        if (!body) {
+        const response = await this.tspClient.request(CommandTypes.GetOutliningSpans, { file }, token);
+        if (response.type !== 'response' || !response.body) {
             return undefined;
         }
         const foldingRanges: lsp.FoldingRange[] = [];
-        for (const span of body) {
+        for (const span of response.body) {
             const foldingRange = this.asFoldingRange(span, document);
             if (foldingRange) {
                 foldingRanges.push(foldingRange);
@@ -1264,8 +1254,12 @@ export class LspServer {
     }
 
     protected async onTsEvent(event: ts.server.protocol.Event): Promise<void> {
-        if (event.event === EventTypes.SementicDiag || event.event === EventTypes.SyntaxDiag || event.event === EventTypes.SuggestionDiag) {
-            this.diagnosticQueue?.updateDiagnostics(event.event, event as ts.server.protocol.DiagnosticEvent);
+        if (event.event === EventName.semanticDiag || event.event === EventName.syntaxDiag || event.event === EventName.suggestionDiag) {
+            const diagnosticEvent = event as ts.server.protocol.DiagnosticEvent;
+            if (diagnosticEvent.body?.diagnostics) {
+                const { file, diagnostics } = diagnosticEvent.body;
+                this.diagnosticQueue?.updateDiagnostics(getDignosticsKind(event), file, diagnostics);
+            }
         }
     }
 
@@ -1357,22 +1351,20 @@ export class LspServer {
     }
 
     async getSemanticTokens(doc: LspDocument, file: string, startOffset: number, endOffset: number, token?: lsp.CancellationToken) : Promise<lsp.SemanticTokens> {
-        try {
-            const result = await this.tspClient.request(
-                CommandTypes.EncodedSemanticClassificationsFull,
-                {
-                    file,
-                    start: startOffset,
-                    length: endOffset - startOffset,
-                    format: '2020',
-                },
-                token,
-            );
+        const response = await this.tspClient.request(
+            CommandTypes.EncodedSemanticClassificationsFull,
+            {
+                file,
+                start: startOffset,
+                length: endOffset - startOffset,
+                format: '2020',
+            },
+            token,
+        );
 
-            const spans = result.body?.spans ?? [];
-            return { data: SemanticTokens.transformSpans(doc, spans) };
-        } catch {
+        if (response.type !== 'response' || !response.body?.spans) {
             return { data: [] };
         }
+        return { data: SemanticTokens.transformSpans(doc, response.body.spans) };
     }
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -65,6 +65,11 @@ const DEFAULT_TEST_CLIENT_INITIALIZATION_OPTIONS: TypeScriptInitializationOption
         jsxAttributeCompletionStyle: 'auto',
         providePrefixAndSuffixTextForRename: true,
     },
+    tsserver: {
+        // With default `auto`, due to dynamic routing, some requests would be routed to syntax server while the project
+        // is loading and return incomplete results so force just a single server for tests.
+        useSyntaxServer: 'never',
+    },
 };
 
 const DEFAULT_WORKSPACE_SETTINGS: WorkspaceConfiguration = {};

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -374,7 +374,7 @@ interface TsserverOptions {
      */
     trace?: TraceValue;
     /**
-     * Controls if TypeScript launches a dedicated server to more quickly handle syntax related operations, such as computing diagnostics or code folding.
+     * Whether a dedicated server is launched to more quickly handle syntax related operations, such as computing diagnostics or code folding.
      *
      * Allowed values:
      *  - auto: Spawn both a full server and a lighter weight server dedicated to syntax operations. The syntax server is used to speed up syntax operations and provide IntelliSense while projects are loading.

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -29,6 +29,7 @@ export enum CommandTypes {
     Close = 'close',
     /** @deprecated Prefer CompletionInfo -- see comment on CompletionsResponse */
     Completions = 'completions',
+    CompletionEntryDetails = 'completionEntryDetails',
     CompletionInfo = 'completionInfo',
     CompletionDetails = 'completionEntryDetails',
     CompileOnSaveAffectedFileList = 'compileOnSaveAffectedFileList',
@@ -250,13 +251,20 @@ export enum OrganizeImportsMode {
 
 // END: Duplicated from typescript/lib/tsserverlibrary.js since we don't want to depend on typescript at runtime
 
-export const enum EventTypes {
-    ConfigFileDiag = 'configFileDiag',
-    SyntaxDiag = 'syntaxDiag',
-    SementicDiag = 'semanticDiag',
-    SuggestionDiag = 'suggestionDiag',
-    ProjectLoadingStart = 'projectLoadingStart',
-    ProjectLoadingFinish = 'projectLoadingFinish',
+export const enum EventName {
+    syntaxDiag = 'syntaxDiag',
+    semanticDiag = 'semanticDiag',
+    suggestionDiag = 'suggestionDiag',
+    configFileDiag = 'configFileDiag',
+    telemetry = 'telemetry',
+    projectLanguageServiceState = 'projectLanguageServiceState',
+    projectsUpdatedInBackground = 'projectsUpdatedInBackground',
+    beginInstallTypes = 'beginInstallTypes',
+    endInstallTypes = 'endInstallTypes',
+    typesInstallerInitializationFailed = 'typesInstallerInitializationFailed',
+    surveyReady = 'surveyReady',
+    projectLoadingStart = 'projectLoadingStart',
+    projectLoadingFinish = 'projectLoadingFinish',
 }
 
 export class KindModifiers {
@@ -365,6 +373,16 @@ interface TsserverOptions {
      * @default 'off'
      */
     trace?: TraceValue;
+    /**
+     * Controls if TypeScript launches a dedicated server to more quickly handle syntax related operations, such as computing diagnostics or code folding.
+     *
+     * Allowed values:
+     *  - auto: Spawn both a full server and a lighter weight server dedicated to syntax operations. The syntax server is used to speed up syntax operations and provide IntelliSense while projects are loading.
+     *  - never: Don't use a dedicated syntax server. Use a single server to handle all IntelliSense operations.
+     *
+     * @default 'auto'
+     */
+    useSyntaxServer?: 'auto' | 'never';
 }
 
 export type TypeScriptInitializeParams = lsp.InitializeParams & {

--- a/src/tsServer/callbackMap.ts
+++ b/src/tsServer/callbackMap.ts
@@ -9,7 +9,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { ServerResponse } from './requests.js';
+import { ServerResponse } from '../typescriptService.js';
 import type { ts } from '../ts-protocol.js';
 
 export interface CallbackItem<R> {

--- a/src/tsp-client.ts
+++ b/src/tsp-client.ts
@@ -9,21 +9,86 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import { URI } from 'vscode-uri';
 import type lsp from 'vscode-languageserver';
 import type { CancellationToken } from 'vscode-jsonrpc';
 import { Logger, PrefixingLogger } from './utils/logger.js';
 import API from './utils/api.js';
-import { CommandTypes, EventTypes } from './ts-protocol.js';
+import { CommandTypes, EventName } from './ts-protocol.js';
 import type { ts } from './ts-protocol.js';
 import type { ILogDirectoryProvider } from './tsServer/logDirectoryProvider.js';
-import { ExecConfig, ServerResponse, TypeScriptRequestTypes } from './tsServer/requests.js';
+import { AsyncTsServerRequests, ClientCapabilities, ClientCapability, ExecConfig, NoResponseTsServerRequests, ServerResponse, StandardTsServerRequests, TypeScriptRequestTypes } from './typescriptService.js';
 import type { ITypeScriptServer, TypeScriptServerExitEvent } from './tsServer/server.js';
 import { TypeScriptServerError } from './tsServer/serverError.js';
 import { TypeScriptServerSpawner } from './tsServer/spawner.js';
 import Tracer, { Trace } from './tsServer/tracer.js';
 import type { TypeScriptVersion, TypeScriptVersionSource } from './tsServer/versionProvider.js';
 import type { LspClient } from './lsp-client.js';
-import type { TsServerLogLevel } from './utils/configuration.js';
+import { SyntaxServerConfiguration, TsServerLogLevel } from './utils/configuration.js';
+
+namespace ServerState {
+    export const enum Type {
+        None,
+        Running,
+        Errored
+    }
+
+    export const None = { type: Type.None } as const;
+
+    export class Running {
+        readonly type = Type.Running;
+
+        constructor(
+            public readonly server: ITypeScriptServer,
+
+            /**
+             * API version obtained from the version picker after checking the corresponding path exists.
+             */
+            public readonly apiVersion: API,
+
+            /**
+             * Version reported by currently-running tsserver.
+             */
+            public tsserverVersion: string | undefined,
+            public languageServiceEnabled: boolean,
+        ) { }
+
+        // public readonly toCancelOnResourceChange = new Set<ToCancelOnResourceChanged>();
+
+        updateTsserverVersion(tsserverVersion: string): void {
+            this.tsserverVersion = tsserverVersion;
+        }
+
+        updateLanguageServiceEnabled(enabled: boolean): void {
+            this.languageServiceEnabled = enabled;
+        }
+    }
+
+    export class Errored {
+        readonly type = Type.Errored;
+        constructor(
+            public readonly error: Error,
+            public readonly tsServerLogFile: string | undefined,
+        ) { }
+    }
+
+    export type State = typeof None | Running | Errored;
+}
+
+export const enum DiagnosticKind {
+    Syntax,
+    Semantic,
+    Suggestion,
+}
+
+export function getDignosticsKind(event: ts.server.protocol.Event): DiagnosticKind {
+    switch (event.event) {
+        case 'syntaxDiag': return DiagnosticKind.Syntax;
+        case 'semanticDiag': return DiagnosticKind.Semantic;
+        case 'suggestionDiag': return DiagnosticKind.Suggestion;
+    }
+    throw new Error('Unknown dignostics kind');
+}
 
 class ServerInitializingIndicator {
     private _loadingProjectName?: string;
@@ -32,13 +97,10 @@ class ServerInitializingIndicator {
     constructor(private lspClient: LspClient) {}
 
     public reset(): void {
-        if (this._loadingProjectName) {
-            this._loadingProjectName = undefined;
-            if (this._task) {
-                const task = this._task;
-                this._task = undefined;
-                task.then(reporter => reporter.done());
-            }
+        if (this._task) {
+            const task = this._task;
+            this._task = undefined;
+            task.then(reporter => reporter.done());
         }
     }
 
@@ -74,12 +136,13 @@ export interface TspClientOptions {
     pluginProbeLocations?: string[];
     onEvent?: (event: ts.server.protocol.Event) => void;
     onExit?: (exitCode: number | null, signal: NodeJS.Signals | null) => void;
+    useSyntaxServer: SyntaxServerConfiguration;
 }
 
 export class TspClient {
     public apiVersion: API;
     public typescriptVersionSource: TypeScriptVersionSource;
-    private primaryTsServer: ITypeScriptServer | null = null;
+    private serverState: ServerState.State = ServerState.None;
     private logger: Logger;
     private tsserverLogger: Logger;
     private loadingIndicator: ServerInitializingIndicator;
@@ -94,11 +157,49 @@ export class TspClient {
         this.tracer = new Tracer(this.tsserverLogger, options.trace);
     }
 
+    public get capabilities(): ClientCapabilities {
+        if (this.options.useSyntaxServer === SyntaxServerConfiguration.Always) {
+            return new ClientCapabilities(
+                ClientCapability.Syntax,
+                ClientCapability.EnhancedSyntax);
+        }
+
+        if (this.apiVersion.gte(API.v400)) {
+            return new ClientCapabilities(
+                ClientCapability.Syntax,
+                ClientCapability.EnhancedSyntax,
+                ClientCapability.Semantic);
+        }
+
+        return new ClientCapabilities(
+            ClientCapability.Syntax,
+            ClientCapability.Semantic);
+    }
+
+    public hasCapabilityForResource(resource: URI, capability: ClientCapability): boolean {
+        if (!this.capabilities.has(capability)) {
+            return false;
+        }
+
+        switch (capability) {
+            case ClientCapability.Semantic: {
+                return ['file', 'untitled'].includes(resource.scheme);
+            }
+            case ClientCapability.Syntax:
+            case ClientCapability.EnhancedSyntax: {
+                return true;
+            }
+        }
+    }
+
     start(): boolean {
         const tsServerSpawner = new TypeScriptServerSpawner(this.apiVersion, this.options.logDirectoryProvider, this.logger, this.tracer);
-        const tsServer = tsServerSpawner.spawn(this.options.typescriptVersion, this.options);
+        const tsServer = tsServerSpawner.spawn(this.options.typescriptVersion, this.capabilities, this.options, {
+            onFatalError: (command, err) => this.fatalError(command, err),
+        });
+        this.serverState = new ServerState.Running(tsServer, this.apiVersion, undefined, true);
         tsServer.onExit((data: TypeScriptServerExitEvent) => {
-            this.primaryTsServer = null;
+            this.serverState = ServerState.None;
             this.shutdown();
             this.tsserverLogger.error(`Exited. Code: ${data.code}. Signal: ${data.signal}`);
             if (this.options.onExit) {
@@ -111,35 +212,40 @@ export class TspClient {
             }
         });
         tsServer.onError((err: Error) => {
+            this.serverState = new ServerState.Errored(err, tsServer.tsServerLogFile);
             if (err) {
                 this.tsserverLogger.error('Exited with error. Error message is: {0}', err.message || err.name);
             }
             this.serviceExited();
         });
         tsServer.onEvent(event => this.dispatchEvent(event));
-        this.primaryTsServer = tsServer;
+        if (this.apiVersion.gte(API.v300) && this.capabilities.has(ClientCapability.Semantic)) {
+            this.loadingIndicator.startedLoadingProject('');
+        }
         return true;
     }
 
     private serviceExited(): void {
-        this.primaryTsServer = null;
+        if (this.serverState.type === ServerState.Type.Running) {
+            this.serverState.server.kill();
+        }
         this.loadingIndicator.reset();
     }
 
     private dispatchEvent(event: ts.server.protocol.Event) {
         switch (event.event) {
-            case EventTypes.SyntaxDiag:
-            case EventTypes.SementicDiag:
-            case EventTypes.SuggestionDiag: {
+            case EventName.syntaxDiag:
+            case EventName.semanticDiag:
+            case EventName.suggestionDiag: {
                 // This event also roughly signals that projects have been loaded successfully (since the TS server is synchronous)
                 this.loadingIndicator.reset();
                 this.options.onEvent?.(event);
                 break;
             }
-            // case EventTypes.ConfigFileDiag:
+            // case EventName.ConfigFileDiag:
             //     this._onConfigDiagnosticsReceived.fire(event as ts.server.protocol.ConfigFileDiagnosticEvent);
             //     break;
-            // case EventTypes.projectLanguageServiceState: {
+            // case EventName.projectLanguageServiceState: {
             //     const body = (event as ts.server.protocol.ProjectLanguageServiceStateEvent).body!;
             //     if (this.serverState.type === ServerState.Type.Running) {
             //         this.serverState.updateLanguageServiceEnabled(body.languageServiceEnabled);
@@ -147,38 +253,40 @@ export class TspClient {
             //     this._onProjectLanguageServiceStateChanged.fire(body);
             //     break;
             // }
-            // case EventTypes.projectsUpdatedInBackground: {
-            //     this.loadingIndicator.reset();
-            //     const body = (event as ts.server.protocol.ProjectsUpdatedInBackgroundEvent).body;
-            //     const resources = body.openFiles.map(file => this.toResource(file));
-            //     this.bufferSyncSupport.getErr(resources);
-            //     break;
-            // }
-            // case EventTypes.beginInstallTypes:
+            case EventName.projectsUpdatedInBackground: {
+                this.loadingIndicator.reset();
+
+                // const body = (event as ts.server.protocol.ProjectsUpdatedInBackgroundEvent).body;
+                // const resources = body.openFiles.map(file => this.toResource(file));
+                // this.bufferSyncSupport.getErr(resources);
+                break;
+            }
+            // case EventName.beginInstallTypes:
             //     this._onDidBeginInstallTypings.fire((event as ts.server.protocol.BeginInstallTypesEvent).body);
             //     break;
-            // case EventTypes.endInstallTypes:
+            // case EventName.endInstallTypes:
             //     this._onDidEndInstallTypings.fire((event as ts.server.protocol.EndInstallTypesEvent).body);
             //     break;
-            // case EventTypes.typesInstallerInitializationFailed:
+            // case EventName.typesInstallerInitializationFailed:
             //     this._onTypesInstallerInitializationFailed.fire((event as ts.server.protocol.TypesInstallerInitializationFailedEvent).body);
             //     break;
-            case EventTypes.ProjectLoadingStart:
+            case EventName.projectLoadingStart:
                 this.loadingIndicator.startedLoadingProject((event as ts.server.protocol.ProjectLoadingStartEvent).body.projectName);
                 break;
-            case EventTypes.ProjectLoadingFinish:
+            case EventName.projectLoadingFinish:
                 this.loadingIndicator.finishedLoadingProject((event as ts.server.protocol.ProjectLoadingFinishEvent).body.projectName);
                 break;
         }
     }
 
-    shutdown(): void {
+    public shutdown(): void {
         if (this.loadingIndicator) {
             this.loadingIndicator.reset();
         }
-        if (this.primaryTsServer) {
-            this.primaryTsServer.kill();
+        if (this.serverState.type === ServerState.Type.Running) {
+            this.serverState.server.kill();
         }
+        this.serverState = ServerState.None;
     }
 
     // High-level API.
@@ -186,7 +294,7 @@ export class TspClient {
     public notify(command: CommandTypes.Open, args: ts.server.protocol.OpenRequestArgs): void;
     public notify(command: CommandTypes.Close, args: ts.server.protocol.FileRequestArgs): void;
     public notify(command: CommandTypes.Change, args: ts.server.protocol.ChangeRequestArgs): void;
-    public notify(command: keyof TypeScriptRequestTypes, args: any): void {
+    public notify(command: keyof NoResponseTsServerRequests, args: any): void {
         this.executeWithoutWaitingForResponse(command, args);
     }
 
@@ -194,12 +302,12 @@ export class TspClient {
         return this.executeAsync(CommandTypes.Geterr, args, token);
     }
 
-    public request<K extends keyof TypeScriptRequestTypes>(
+    public request<K extends keyof StandardTsServerRequests>(
         command: K,
-        args: TypeScriptRequestTypes[K][0],
+        args: StandardTsServerRequests[K][0],
         token?: CancellationToken,
         config?: ExecConfig,
-    ): Promise<TypeScriptRequestTypes[K][1]> {
+    ): Promise<ServerResponse.Response<StandardTsServerRequests[K][1]>> {
         return this.execute(command, args, token, config);
     }
 
@@ -255,7 +363,10 @@ export class TspClient {
         return executions[0]!;
     }
 
-    public executeWithoutWaitingForResponse(command: keyof TypeScriptRequestTypes, args: any): void {
+    public executeWithoutWaitingForResponse<K extends keyof NoResponseTsServerRequests>(
+        command: K,
+        args: NoResponseTsServerRequests[K][0],
+    ): void {
         this.executeImpl(command, args, {
             isAsync: false,
             token: undefined,
@@ -263,7 +374,11 @@ export class TspClient {
         });
     }
 
-    public executeAsync(command: keyof TypeScriptRequestTypes, args: ts.server.protocol.GeterrRequestArgs, token: CancellationToken): Promise<ServerResponse.Response<ts.server.protocol.Response>> {
+    public executeAsync<K extends keyof AsyncTsServerRequests>(
+        command: K,
+        args: AsyncTsServerRequests[K][0],
+        token: CancellationToken,
+    ): Promise<ServerResponse.Response<ts.server.protocol.Response>> {
         return this.executeImpl(command, args, {
             isAsync: true,
             token,
@@ -272,8 +387,9 @@ export class TspClient {
     }
 
     private executeImpl(command: keyof TypeScriptRequestTypes, args: any, executeInfo: { isAsync: boolean; token?: CancellationToken; expectsResult: boolean; lowPriority?: boolean; requireSemantic?: boolean; }): Array<Promise<ServerResponse.Response<ts.server.protocol.Response>> | undefined> {
-        if (this.primaryTsServer) {
-            return this.primaryTsServer.executeImpl(command, args, executeInfo);
+        const serverState = this.serverState;
+        if (serverState.type === ServerState.Type.Running) {
+            return serverState.server.executeImpl(command, args, executeInfo);
         } else {
             return [Promise.resolve(ServerResponse.NoServer)];
         }
@@ -285,11 +401,12 @@ export class TspClient {
             this.tsserverLogger.error(error.serverErrorText);
         }
 
-        if (this.primaryTsServer) {
+        if (this.serverState.type === ServerState.Type.Running) {
             this.logger.info('Killing TS Server');
-            this.primaryTsServer.kill();
+            const logfile = this.serverState.server.tsServerLogFile;
+            this.serverState.server.kill();
             if (error instanceof TypeScriptServerError) {
-                this.primaryTsServer = null;
+                this.serverState = new ServerState.Errored(error, logfile);
             }
         }
     }

--- a/src/typescriptService.ts
+++ b/src/typescriptService.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 /*
- * Copyright (C) 2022 TypeFox and others.
+ * Copyright (C) 2023 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 import { URI } from 'vscode-uri';
-import { CommandTypes } from '../ts-protocol.js';
-import type { ts } from '../ts-protocol.js';
-import { ExecutionTarget } from './server.js';
+import { CommandTypes } from './ts-protocol.js';
+import type { ts } from './ts-protocol.js';
+import { ExecutionTarget } from './tsServer/server.js';
 
 export enum ServerType {
     Syntax = 'syntax',
@@ -29,15 +29,47 @@ export namespace ServerResponse {
     export type Response<T extends ts.server.protocol.Response> = T | Cancelled | typeof NoContent | typeof NoServer;
 }
 
-export interface TypeScriptRequestTypes {
+export type ExecConfig = {
+    readonly lowPriority?: boolean;
+    readonly nonRecoverable?: boolean;
+    readonly cancelOnResourceChange?: URI;
+    readonly executionTarget?: ExecutionTarget;
+};
+
+export enum ClientCapability {
+    /**
+     * Basic syntax server. All clients should support this.
+     */
+    Syntax,
+
+    /**
+     * Advanced syntax server that can provide single file IntelliSense.
+     */
+    EnhancedSyntax,
+
+    /**
+     * Complete, multi-file semantic server
+     */
+    Semantic,
+}
+
+export class ClientCapabilities {
+    private readonly capabilities: ReadonlySet<ClientCapability>;
+
+    constructor(...capabilities: ClientCapability[]) {
+        this.capabilities = new Set(capabilities);
+    }
+
+    public has(capability: ClientCapability): boolean {
+        return this.capabilities.has(capability);
+    }
+}
+
+export interface StandardTsServerRequests {
     [CommandTypes.ApplyCodeActionCommand]: [ts.server.protocol.ApplyCodeActionCommandRequestArgs, ts.server.protocol.ApplyCodeActionCommandResponse];
-    [CommandTypes.Change]: [ts.server.protocol.ChangeRequestArgs, null];
-    [CommandTypes.Close]: [ts.server.protocol.FileRequestArgs, null];
-    [CommandTypes.CompilerOptionsForInferredProjects]: [ts.server.protocol.SetCompilerOptionsForInferredProjectsArgs, ts.server.protocol.SetCompilerOptionsForInferredProjectsResponse];
     [CommandTypes.CompletionDetails]: [ts.server.protocol.CompletionDetailsRequestArgs, ts.server.protocol.CompletionDetailsResponse];
     [CommandTypes.CompletionInfo]: [ts.server.protocol.CompletionsRequestArgs, ts.server.protocol.CompletionInfoResponse];
     [CommandTypes.Configure]: [ts.server.protocol.ConfigureRequestArguments, ts.server.protocol.ConfigureResponse];
-    [CommandTypes.ConfigurePlugin]: [ts.server.protocol.ConfigurePluginRequestArguments, ts.server.protocol.ConfigurePluginResponse];
     [CommandTypes.Definition]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DefinitionResponse];
     [CommandTypes.DefinitionAndBoundSpan]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DefinitionInfoAndBoundSpanResponse];
     [CommandTypes.DocCommentTemplate]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.DocCommandTemplateResponse];
@@ -51,14 +83,12 @@ export interface TypeScriptRequestTypes {
     [CommandTypes.GetCombinedCodeFix]: [ts.server.protocol.GetCombinedCodeFixRequestArgs, ts.server.protocol.GetCombinedCodeFixResponse];
     [CommandTypes.GetEditsForFileRename]: [ts.server.protocol.GetEditsForFileRenameRequestArgs, ts.server.protocol.GetEditsForFileRenameResponse];
     [CommandTypes.GetEditsForRefactor]: [ts.server.protocol.GetEditsForRefactorRequestArgs, ts.server.protocol.GetEditsForRefactorResponse];
-    [CommandTypes.Geterr]: [ts.server.protocol.GeterrRequestArgs, any];
     [CommandTypes.GetOutliningSpans]: [ts.server.protocol.FileRequestArgs, ts.server.protocol.OutliningSpansResponse];
     [CommandTypes.GetSupportedCodeFixes]: [null, ts.server.protocol.GetSupportedCodeFixesResponse];
     [CommandTypes.Implementation]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.ImplementationResponse];
     [CommandTypes.JsxClosingTag]: [ts.server.protocol.JsxClosingTagRequestArgs, ts.server.protocol.JsxClosingTagResponse];
     [CommandTypes.Navto]: [ts.server.protocol.NavtoRequestArgs, ts.server.protocol.NavtoResponse];
     [CommandTypes.NavTree]: [ts.server.protocol.FileRequestArgs, ts.server.protocol.NavTreeResponse];
-    [CommandTypes.Open]: [ts.server.protocol.OpenRequestArgs, null];
     [CommandTypes.OrganizeImports]: [ts.server.protocol.OrganizeImportsRequestArgs, ts.server.protocol.OrganizeImportsResponse];
     [CommandTypes.PrepareCallHierarchy]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.PrepareCallHierarchyResponse];
     [CommandTypes.ProvideCallHierarchyIncomingCalls]: [ts.server.protocol.FileLocationRequestArgs, ts.server.protocol.ProvideCallHierarchyIncomingCallsResponse];
@@ -74,10 +104,17 @@ export interface TypeScriptRequestTypes {
     [CommandTypes.UpdateOpen]: [ts.server.protocol.UpdateOpenRequestArgs, ts.server.protocol.Response];
 }
 
-export type ExecConfig = {
-    readonly lowPriority?: boolean;
-    readonly nonRecoverable?: boolean;
-    readonly cancelOnResourceChange?: URI;
-    readonly executionTarget?: ExecutionTarget;
-};
+export interface NoResponseTsServerRequests {
+    [CommandTypes.Change]: [ts.server.protocol.ChangeRequestArgs, null];
+    [CommandTypes.Close]: [ts.server.protocol.FileRequestArgs, null];
+    [CommandTypes.CompilerOptionsForInferredProjects]: [ts.server.protocol.SetCompilerOptionsForInferredProjectsArgs, ts.server.protocol.SetCompilerOptionsForInferredProjectsResponse];
+    [CommandTypes.ConfigurePlugin]: [ts.server.protocol.ConfigurePluginRequestArguments, ts.server.protocol.ConfigurePluginResponse];
+    [CommandTypes.Open]: [ts.server.protocol.OpenRequestArgs, null];
+}
 
+export interface AsyncTsServerRequests {
+    [CommandTypes.Geterr]: [ts.server.protocol.GeterrRequestArgs, ts.server.protocol.Response];
+    [CommandTypes.GeterrForProject]: [ts.server.protocol.GeterrForProjectRequestArgs, ts.server.protocol.Response];
+}
+
+export type TypeScriptRequestTypes = StandardTsServerRequests & NoResponseTsServerRequests & AsyncTsServerRequests;

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -56,3 +56,19 @@ export interface TypeScriptServiceConfiguration {
     readonly tsserverLogVerbosity: TsServerLogLevel;
     readonly tsserverPath?: string;
 }
+
+export const enum SyntaxServerConfiguration {
+    Never,
+    Always,  // Unused
+    Auto,
+}
+
+export function toSyntaxServerConfiguration(value?: string): SyntaxServerConfiguration {
+    switch (value) {
+        case 'never': return SyntaxServerConfiguration.Never;
+        // case 'always': return SyntaxServerConfiguration.Always;
+        case 'auto': return SyntaxServerConfiguration.Auto;
+    }
+
+    return SyntaxServerConfiguration.Auto;
+}


### PR DESCRIPTION
Ported code from VSCode that enables two tsserver instances, one for "syntax" requests and one for "semantic" requests. This should ensure that the more expensive requests like semantic tokens or diagnostic computations don't block more acute requests like completions.

The default is to run with syntax and semantic servers enabled.

Resolves #650 (?)
Resolves #675 (?)
