### PR TITLE
feat: handle moduleDetection in inferred project compiler options

### DIFF
--- a/src/configuration-manager.ts
+++ b/src/configuration-manager.ts
@@ -71,6 +71,7 @@ export interface WorkspaceConfigurationLanguageOptions {
 export interface WorkspaceConfigurationImplicitProjectConfigurationOptions {
     checkJs?: boolean;
     experimentalDecorators?: boolean;
+    moduleDetection?: string;
     module?: string;
     strictFunctionTypes?: boolean;
     strictNullChecks?: boolean;

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -123,6 +123,12 @@ export enum ModuleKind {
     ESNext = 'ESNext'
 }
 
+export enum ModuleDetectionKind {
+    auto = 'auto',
+    legacy = 'legacy',
+    force = 'force'
+}
+
 export enum ModuleResolutionKind {
     Classic = 'Classic',
     Node = 'Node'

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -45,6 +45,10 @@ export function getInferredProjectCompilerOptions(
         projectConfig.module = workspaceConfig.module as ts.server.protocol.ModuleKind;
     }
 
+    if (workspaceConfig.moduleDetection) {
+        projectConfig.moduleDetection = workspaceConfig.moduleDetection as ts.server.protocol.ModuleDetectionKind;
+    }
+
     if (workspaceConfig.target) {
         projectConfig.target = workspaceConfig.target as ts.server.protocol.ScriptTarget;
     }


### PR DESCRIPTION
This PR enables setting the `moduleDetection` option in the implicit configuration options.