### PR TITLE
fix: don't report InternalError on tsserver error response

### DIFF
--- a/src/tsp-client.ts
+++ b/src/tsp-client.ts
@@ -10,6 +10,7 @@
  */
 
 import { URI } from 'vscode-uri';
+import { ResponseError } from 'vscode-languageserver';
 import type lsp from 'vscode-languageserver';
 import type { CancellationToken } from 'vscode-jsonrpc';
 import { Logger, PrefixingLogger } from './utils/logger.js';
@@ -302,13 +303,17 @@ export class TspClient {
         return this.executeAsync(CommandTypes.Geterr, args, token);
     }
 
-    public request<K extends keyof StandardTsServerRequests>(
+    public async request<K extends keyof StandardTsServerRequests>(
         command: K,
         args: StandardTsServerRequests[K][0],
         token?: CancellationToken,
         config?: ExecConfig,
     ): Promise<ServerResponse.Response<StandardTsServerRequests[K][1]>> {
-        return this.execute(command, args, token, config);
+        try {
+            return await this.execute(command, args, token, config);
+        } catch (error) {
+            throw new ResponseError(1, (error as Error).message);
+        }
     }
 
     // Low-level API.


### PR DESCRIPTION
Don't report an `InternalError` when `tsserver` crashes on handling request. That error code is reserved for JSON-RPC communication so it might be receive more harsh handling from clients.

Fixes #694