### PR TITLE
fix: verbosity of the "Using Typescript version" message

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -103,7 +103,7 @@ export class LspServer {
 
         const typescriptVersion = this.findTypescriptVersion(tsserver?.path);
         if (typescriptVersion) {
-            this.options.lspClient.logMessage({ type: LogLevel.Info, message: `Using Typescript version (${typescriptVersion.source}) ${typescriptVersion.versionString} from path "${typescriptVersion.tsServerPath}"` });
+            this.options.lspClient.logMessage({ type: lsp.MessageType.Info, message: `Using Typescript version (${typescriptVersion.source}) ${typescriptVersion.versionString} from path "${typescriptVersion.tsServerPath}"` });
         } else {
             throw Error('Could not find a valid TypeScript installation. Please ensure that the "typescript" dependency is installed in the workspace or that a valid `tsserver.path` is specified. Exiting.');
         }


### PR DESCRIPTION
The initial `Using Typescript version` is using the incorrect verbosity level due to a difference between the values of the `LogLevel` enum and `lsp.MessageType`. `lsp.MessageType` is correct, so switching to that will fix it.

I can also update the `LogLevel` enum to set the same values as the lsp log levels if you'd like.