### PR TITLE
refactor: remove deprecated CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,8 @@ typescript-language-server --stdio
     -V, --version                          output the version number
     --stdio                                use stdio (required option)
     --log-level <log-level>                A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `3`.
-    --tsserver-log-verbosity <verbosity>   [deprecated] Specify tsserver log verbosity (off, terse, normal, verbose). Defaults to `normal`. example: --tsserver-log-verbosity=verbose
-    --tsserver-path <path>                 [deprecated] Specify path to tsserver directory. example: --tsserver-path=/Users/me/typescript/lib/
     -h, --help                             output usage information
 ```
-
-> The `--tsserver-log-verbosity` and `--tsserver-path` options are deprecated and it is recommended to pass those through corresponding `tsserver.*` `initializationOptions` instead.
-
-> Note: The path passed to `--tsserver-path` should be a path to the `[...]/typescript/lib/tssserver.js` file or to the `[...]/typescript/lib/` directory and not to the shell script `[...]/node_modules/.bin/tsserver`. Though for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script.
 
 ## initializationOptions
 
@@ -110,6 +104,10 @@ interface TsserverOptions {
     logVerbosity?: 'off' | 'terse' | 'normal' | 'requestTime' | 'verbose';
     /**
      * The path to the `tsserver.js` file or the typescript lib directory. For example: `/Users/me/typescript/lib/tsserver.js`.
+     *
+     * Note: The path should point at the `[...]/typescript/lib/tssserver.js` file or the `[...]/typescript/lib/` directory
+     * and not the shell script (`[...]/node_modules/.bin/tsserver`) but for backward-compatibility reasons, the server will try
+     * to do the right thing even when passed a path to the shell script.
      */
     path?: string;
     /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,6 @@ import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 import lsp from 'vscode-languageserver';
 import { createLspConnection } from './lsp-connection.js';
-import { TsServerLogLevel } from './utils/configuration.js';
 
 const DEFAULT_LOG_LEVEL = lsp.MessageType.Info;
 const { version } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), { encoding: 'utf8' }));
@@ -18,9 +17,6 @@ const program = new Command('typescript-language-server')
     .version(version)
     .requiredOption('--stdio', 'use stdio')
     .option('--log-level <logLevel>', 'A number indicating the log level (4 = log, 3 = info, 2 = warn, 1 = error). Defaults to `2`.')
-    .option('--tsserver-log-verbosity <tsserverLogVerbosity>', '[deprecated] Specify a tsserver log verbosity (terse, normal, verbose). Defaults to `normal`.' +
-      ' example: --tsserver-log-verbosity verbose')
-    .option('--tsserver-path <path>', '[deprecated] Specify path to tsserver.js or the lib directory. example: --tsserver-path=/Users/me/typescript/lib/tsserver.js')
     .parse(process.argv);
 
 const options = program.opts();
@@ -35,7 +31,5 @@ if (options.logLevel) {
 }
 
 createLspConnection({
-    cmdLineTsserverPath: options.tsserverPath as string,
-    cmdLineTsserverLogVerbosity: TsServerLogLevel.fromString(options.tsserverLogVerbosity),
     showMessageLevel: logLevel as lsp.MessageType,
 }).listen();

--- a/src/lsp-connection.ts
+++ b/src/lsp-connection.ts
@@ -9,11 +9,8 @@ import lsp from 'vscode-languageserver/node.js';
 import { LspClientLogger } from './utils/logger.js';
 import { LspServer } from './lsp-server.js';
 import { LspClientImpl } from './lsp-client.js';
-import type { TsServerLogLevel } from './utils/configuration.js';
 
 export interface LspConnectionOptions {
-    cmdLineTsserverPath: string;
-    cmdLineTsserverLogVerbosity: TsServerLogLevel;
     showMessageLevel: lsp.MessageType;
 }
 
@@ -24,8 +21,6 @@ export function createLspConnection(options: LspConnectionOptions): lsp.Connecti
     const server: LspServer = new LspServer({
         logger,
         lspClient,
-        tsserverPath: options.cmdLineTsserverPath,
-        tsserverLogVerbosity: options.cmdLineTsserverLogVerbosity,
     });
 
     connection.onInitialize(server.initialize.bind(server));

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -153,7 +153,7 @@ export class LspServer {
                 trace: Trace.fromString(tsserver?.trace || 'off'),
                 typescriptVersion,
                 logDirectoryProvider: new LogDirectoryProvider(this.getLogDirectoryPath(userInitializationOptions)),
-                logVerbosity: tsserverLogVerbosity ?? this.options.tsserverLogVerbosity,
+                logVerbosity: tsserverLogVerbosity ?? TsServerLogLevel.Off,
                 disableAutomaticTypingAcquisition,
                 maxTsServerMemory,
                 npmLocation,
@@ -304,7 +304,7 @@ export class LspServer {
     }
 
     private findTypescriptVersion(userTsserverPath: string | undefined): TypeScriptVersion | null {
-        const typescriptVersionProvider = new TypeScriptVersionProvider(userTsserverPath || this.options.tsserverPath, this.logger);
+        const typescriptVersionProvider = new TypeScriptVersionProvider(userTsserverPath, this.logger);
         // User-provided tsserver path.
         const userSettingVersion = typescriptVersionProvider.getUserSettingVersion();
         if (userSettingVersion) {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -146,7 +146,7 @@ export class LspServer {
             useLabelDetailsInCompletionEntries: this.features.completionLabelDetails,
         });
 
-        const tsserverLogVerbosity = tsserver?.logVerbosity && TsServerLogLevel.fromString(tsserver?.logVerbosity);
+        const tsserverLogVerbosity = tsserver?.logVerbosity && TsServerLogLevel.fromString(tsserver.logVerbosity);
         const started = this.tsClient.start(
             this.workspaceRoot,
             {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -17,8 +17,6 @@ import { TypeScriptInitializationOptions } from './ts-protocol.js';
 import { LspClient, WithProgressOptions } from './lsp-client.js';
 import { LspServer } from './lsp-server.js';
 import { ConsoleLogger, LogLevel } from './utils/logger.js';
-import { TypeScriptVersionProvider } from './tsServer/versionProvider.js';
-import { TsServerLogLevel } from './utils/configuration.js';
 
 const CONSOLE_LOG_LEVEL = LogLevel.fromString(process.env.CONSOLE_LOG_LEVEL);
 export const PACKAGE_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -204,7 +202,6 @@ export class TestLspServer extends LspServer {
 
 interface TestLspServerOptions {
     rootUri: string | null;
-    tsserverLogVerbosity?: TsServerLogLevel;
     publishDiagnostics: (args: lsp.PublishDiagnosticsParams) => void;
     clientCapabilitiesOverride?: lsp.ClientCapabilities;
 }
@@ -212,13 +209,9 @@ interface TestLspServerOptions {
 export async function createServer(options: TestLspServerOptions): Promise<TestLspServer> {
     const logger = new ConsoleLogger(CONSOLE_LOG_LEVEL);
     const lspClient = new TestLspClient(options, logger);
-    const typescriptVersionProvider = new TypeScriptVersionProvider(undefined, logger);
-    const bundled = typescriptVersionProvider.bundledVersion();
     const server = new TestLspServer({
         logger,
         lspClient,
-        tsserverLogVerbosity: TsServerLogLevel.Off,
-        tsserverPath: bundled!.tsServerPath,
     });
 
     lspClient.addApplyWorkspaceEditListener(args => {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -53,8 +53,6 @@ export namespace TsServerLogLevel {
 export interface LspServerConfiguration {
     readonly logger: Logger;
     readonly lspClient: LspClient;
-    readonly tsserverLogVerbosity: TsServerLogLevel;
-    readonly tsserverPath?: string;
 }
 
 export const enum SyntaxServerConfiguration {


### PR DESCRIPTION
Remove `--tsserver-path` and `--tsserver-log-verbosity` CLI arguments which were deprecated and should be used through equivalent `tsserver` options in `initializationOptions`.

This was really meant to be done on making the last major (v4) release but I forgot so will sneakily include it for 4.1.