### PR TITLE
fix: try to fallback to valid languageId when invalid provided

### DIFF
--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -2423,3 +2423,24 @@ describe('linked editing', () => {
         ]);
     });
 });
+
+describe('handles invalid languageId', () => {
+    it('simple test', async () => {
+        const textDocument = {
+            uri: uri('foo.tsx'),
+            languageId: 'tsx',
+            version: 1,
+            text: 'let bar = <div></div>',
+        };
+        await openDocumentAndWaitForDiagnostics(server, textDocument);
+        const position = positionAfter(textDocument, '<div');
+        const linedEditRanges = await server.linkedEditingRange({
+            textDocument,
+            position,
+        });
+        expect(linedEditRanges?.ranges).toStrictEqual([
+            { start: { line: 0, character: 11 }, end: { line: 0, character: 14 } },
+            { start: { line: 0, character: 17 }, end: { line: 0, character: 20 } },
+        ]);
+    });
+});

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -350,7 +350,7 @@ export class LspServer {
         }
 
         if (!this.tsClient.openTextDocument(params.textDocument)) {
-            throw new Error(`Cannot open document '${params.textDocument.uri}'.`);
+            throw new Error(`Cannot open document '${params.textDocument.uri}' (languageId: ${params.textDocument.languageId}).`);
         }
     }
 

--- a/src/ts-client.ts
+++ b/src/ts-client.ts
@@ -171,7 +171,7 @@ export class TsClient implements ITypeScriptServiceClient {
         logger: Logger,
         lspClient: LspClient,
     ) {
-        this.documents = new LspDocuments(this, onCaseInsensitiveFileSystem);
+        this.documents = new LspDocuments(this, lspClient, onCaseInsensitiveFileSystem);
         this.logger = new PrefixingLogger(logger, '[tsclient]');
         this.tsserverLogger = new PrefixingLogger(this.logger, '[tsserver]');
         this.lspClient = lspClient;


### PR DESCRIPTION
Fixup `languageId` if an invalid one was provided when opening a document.

This logic is slated to be removed in next major release.

Fixes #794