### PR TITLE
fix: revert to `Node` value for `moduleResolution` in implicit config

### DIFF
--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -127,7 +127,7 @@ export enum ModuleKind {
 export enum ModuleResolutionKind {
     Classic = 'Classic',
     Node = 'Node',
-    Bundler = 'Bundler'
+    // Bundler = 'Bundler'
 }
 
 export enum SemicolonPreference {

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -20,9 +20,7 @@ export function getInferredProjectCompilerOptions(
 ): ts.server.protocol.ExternalProjectCompilerOptions {
     const projectConfig: ts.server.protocol.ExternalProjectCompilerOptions = {
         module: ModuleKind.ESNext,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore ModuleResolutionKind enum doesn't include "Bundler" value in TS
-        moduleResolution: version.gte(API.v500) ? ModuleResolutionKind.Bundler : ModuleResolutionKind.Node,
+        moduleResolution: ModuleResolutionKind.Node,
         target: ScriptTarget.ES2022,
         jsx: JsxEmit.React,
     };


### PR DESCRIPTION
Following the fix for https://github.com/microsoft/vscode/issues/196554