### PR TITLE
fix: avoid triggering unhandled exception when tsserver crashes

### DIFF
--- a/src/ts-client.ts
+++ b/src/ts-client.ts
@@ -445,10 +445,12 @@ export class TsClient implements ITypeScriptServiceClient {
                     expectsResult: true,
                     ...config,
                 });
-                executions[0]!.finally(() => {
-                    runningServerState.toCancelOnResourceChange.delete(inFlight);
-                    source.dispose();
-                });
+                executions[0]!
+                    .catch(() => {})
+                    .finally(() => {
+                        runningServerState.toCancelOnResourceChange.delete(inFlight);
+                        source.dispose();
+                    });
             }
         }
 


### PR DESCRIPTION
Errors during tsserver request handling were triggering an unhandled exception and subsequently cause the language server process to exit. Make sure that the promise that is "forked" is also catching exception so that exceptions are caught. The tsserver is able to keep running on error so we can keep running also.

It seems like in vscode the extension process has global handler for unhandled exceptions so even though it doesn't use `catch` on that promise, it still catches the exception and doesn't crash.

Resolves #803 (kind of)