### PR TITLE
fix: add folder filter in server capabilities for `willRename`

### DIFF
--- a/src/lsp-server.spec.ts
+++ b/src/lsp-server.spec.ts
@@ -2385,12 +2385,14 @@ describe('completions without client snippet support', () => {
 });
 
 describe('fileOperations', () => {
-    it('willRenameFiles', async () => {
+    it('willRenameFiles - rename file', async () => {
+        // TODO: This test depends on ensureConfigurationForDocument being executed first (even for a different file).
         const edit = await server.willRenameFiles({
             files: [{ oldUri: uri('module1.ts'), newUri: uri('new_module1_name.ts') }],
         });
         expect(edit.changes).toBeDefined();
         expect(Object.keys(edit.changes!)).toHaveLength(1);
+        // module2 imports from renamed file
         expect(edit.changes![uri('module2.ts')]).toEqual([
             {
                 range: {
@@ -2398,6 +2400,25 @@ describe('fileOperations', () => {
                     end: { line: 0, character: 34 },
                 },
                 newText:'./new_module1_name',
+            },
+        ]);
+    });
+
+    it('willRenameFiles - rename directory', async () => {
+        // TODO: This test depends on ensureConfigurationForDocument being executed (even for a different file).
+        const edit = await server.willRenameFiles({
+            files: [{ oldUri: uri('rename1'), newUri: uri('rename2') }],
+        });
+        expect(edit.changes).toBeDefined();
+        expect(Object.keys(edit.changes!)).toHaveLength(1);
+        // module3 imports from renamed directory
+        expect(edit.changes![uri('module3.ts')]).toEqual([
+            {
+                range: {
+                    start:{ line: 0, character: 31 },
+                    end: { line: 0, character: 44 },
+                },
+                newText:'./rename2/var',
             },
         ]);
     });

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -271,15 +271,18 @@ export class LspServer {
                         willRename: {
                             filters: [
                                 {
-                                    scheme: "file",
+                                    scheme: 'file',
                                     pattern: {
-                                        glob: "**/*.{ts,js,jsx,tsx,mjs,mts,cjs,cts}",
-                                        matches: "file",
+                                        glob: '**/*.{ts,js,jsx,tsx,mjs,mts,cjs,cts}',
+                                        matches: 'file',
                                     },
                                 },
                                 {
-                                    scheme: "file",
-                                    pattern: { glob: "**", matches: "folder" },
+                                    scheme: 'file',
+                                    pattern: {
+                                        glob: '**',
+                                        matches: 'folder',
+                                    },
                                 },
                             ],
                         },

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -269,10 +269,19 @@ export class LspServer {
                 workspace: {
                     fileOperations: {
                         willRename: {
-                            filters: [{
-                                scheme: 'file',
-                                pattern: { glob: '**/*.{ts,js,jsx,tsx,mjs,mts,cjs,cts}', matches: 'file' },
-                            }],
+                            filters: [
+                                {
+                                    scheme: "file",
+                                    pattern: {
+                                        glob: "**/*.{ts,js,jsx,tsx,mjs,mts,cjs,cts}",
+                                        matches: "file",
+                                    },
+                                },
+                                {
+                                    scheme: "file",
+                                    pattern: { glob: "**", matches: "folder" },
+                                },
+                            ],
                         },
                     },
                 },

--- a/test-data/module3.ts
+++ b/test-data/module3.ts
@@ -1,0 +1,3 @@
+import { fileInRenamed } from './rename1/var';
+
+export { fileInRenamed };

--- a/test-data/rename1/var.ts
+++ b/test-data/rename1/var.ts
@@ -1,0 +1,1 @@
+export const fileInRenamed = true;


### PR DESCRIPTION
typescript-language-server does support willRenameFiles on `folder` but it only provides filter for `file`, other servers like rust-analyzer explicitly specify this filter. The absence of this filter also causes issues in willRenameFiles implementation on the client side if the client only tracks things specified by the filters, i.e it doesn't send requests on folder renamed.