### PR TITLE
add tsserver.fallbackPath to initialization options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,8 @@ Specifies additional options related to the internal `tsserver` process, like tr
 
 **path** [string] The path to the `tsserver.js` file or the typescript lib directory. For example: `/Users/me/typescript/lib/tsserver.js`. Note: The path should point at the `[...]/typescript/lib/tssserver.js` file or the `[...]/typescript/lib/` directory and not the shell script (`[...]/node_modules/.bin/tsserver`) but for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script. **Default**: `undefined`
 
+**fallbackPath** [string] The path to the `tsserver.js` file or the typescript lib directory to use when `tsserver.path` is unspecified/invalid and the `tsserver` isn't available via the current workspace. For example: `/Users/me/typescript/lib/tsserver.js`. Note: The path should point at the `[...]/typescript/lib/tssserver.js` file or the `[...]/typescript/lib/` directory and not the shell script (`[...]/node_modules/.bin/tsserver`) but for backward-compatibility reasons, the server will try to do the right thing even when passed a path to the shell script. **Default**: `undefined`
+
 **trace** [string] The verbosity of logging of the tsserver communication. Delivered through the LSP messages and not related to file logging. Allowed values are: `'off'`, `'messages'`, `'verbose'`. **Default**: `'off'`
 
 **useSyntaxServer** [string] Whether a dedicated server is launched to more quickly handle syntax related operations, such as computing diagnostics or code folding. **Default**: `'auto'`. Allowed values:

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -375,6 +375,12 @@ interface TsserverOptions {
      */
     path?: string;
     /**
+     * The fallback path to the `tsserver.js` file or the typescript lib directory. For example: `/Users/me/typescript/lib/tsserver.js`.
+     *
+     * This path gets used when `.path` isn't set or valid, and detecting the file from the current active workspace fails.
+     */
+    fallbackPath?: string;
+    /**
      * The verbosity of logging the tsserver communication through the LSP messages.
      * This doesn't affect the file logging.
      * @default 'off'


### PR DESCRIPTION
In order to support the broad variety of projects that replit users encounter, we at replit have been [explicitly passing the `typescript` package from `nixpkgs` to `typescript-language-server`](https://github.com/replit/nixmodules/blob/fe25c7a40ef8aa677493c8b7a49d13f04688902c/pkgs/modules/typescript-language-server/default.nix#L20) since April of last year. This has the unfortunate side-effect of not using the `tsserver` that's available in the user's workspace, which means the user may get inaccurate results in their completions.

This PR introduces a new option to `initializationOptions.tsserver`, `fallbackPath`. It has similar semantics to `initializationOptions.tsserver.path`, but is checked if
1. `typescript` passed via `initializationOptions.tsserver.path` is absent or invalid
2. `typescript` available via the workspace is absent or invalid

i've [tested that this works on Replit](https://github.com/replit/nixmodules/blob/9268ae3f1aa7c8f1520fcd40a4179f148521b8e2/pkgs/modules/typescript-language-server/default.nix#L21)