### PR TITLE
fix: avoid sending window/workDoneProgress/create before init

### DIFF
--- a/src/ts-client.ts
+++ b/src/ts-client.ts
@@ -360,9 +360,6 @@ export class TsClient implements ITypeScriptServiceClient {
             this.serviceExited();
         });
         tsServer.onEvent(event => this.dispatchEvent(event));
-        if (this.apiVersion.gte(API.v300) && this.capabilities.has(ClientCapability.Semantic)) {
-            this.loadingIndicator.startedLoadingProject('');
-        }
         return true;
     }
 


### PR DESCRIPTION
Don't create loading progress indicator synchronously during `initialize` request as it's against the spec. It will be created later from tsserver's `projectLoadingStart` event.

Fixes #845 