### PR TITLE
fix: out of date diagnostics after closing and re-opening a file

### DIFF
--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -50,8 +50,8 @@ class FileDiagnostics {
     }
 
     public onDidClose(): void {
-        this.publishDiagnostics();
         this.diagnosticsPerKind.clear();
+        this.publishDiagnostics();
         this.closed = true;
     }
 

--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -106,6 +106,7 @@ export class DiagnosticEventQueue {
         const uri = this.client.toResource(file).toString();
         const diagnosticsForFile = this.diagnostics.get(uri);
         diagnosticsForFile?.onDidClose();
+        this.diagnostics.delete(uri);
     }
 
     /**


### PR DESCRIPTION
diagnostics would malfunction for a file that was closed and later re-opened