### PR TITLE
perf: skip diagnostic update event on no changes

### DIFF
--- a/src/diagnostic-queue.ts
+++ b/src/diagnostic-queue.ts
@@ -27,6 +27,10 @@ class FileDiagnostics {
     ) { }
 
     public update(kind: DiagnosticKind, diagnostics: ts.server.protocol.Diagnostic[]): void {
+        if (this.diagnosticsPerKind.get(kind)?.length === 0 && diagnostics.length === 0) {
+            return;
+        }
+
         this.diagnosticsPerKind.set(kind, diagnostics);
         this.firePublishDiagnostics();
     }
@@ -87,6 +91,7 @@ export class DiagnosticEventQueue {
         if (this.ignoredDiagnosticCodes.size) {
             diagnostics = diagnostics.filter(diagnostic => !this.isDiagnosticIgnored(diagnostic));
         }
+
         const uri = this.client.toResourceUri(file);
         const diagnosticsForFile = this.diagnostics.get(uri) || new FileDiagnostics(uri, this.publishDiagnostics, this.client, this.features);
         diagnosticsForFile.update(kind, diagnostics);


### PR DESCRIPTION
When diagnostic count was 0 in the previous update and is still 0 then there is no need to send update notification.