### PR TITLE
fix(previewer): mark `@example` and `@default` code blocks as TS

### DIFF
--- a/src/utils/previewer.test.ts
+++ b/src/utils/previewer.test.ts
@@ -99,7 +99,7 @@ describe('typescript.previewer', () => {
                     text: 'code();',
                 },
             ], noopToResource),
-        ).toBe('*@example*  \n```\ncode();\n```',
+        ).toBe('*@example*  \n```typescript\ncode();\n```',
         );
     });
 
@@ -123,7 +123,7 @@ describe('typescript.previewer', () => {
                     text: '<caption>Not code</caption>\ncode();',
                 },
             ], noopToResource),
-        ).toBe('*@example*  \nNot code\n```\ncode();\n```',
+        ).toBe('*@example*  \nNot code\n```typescript\ncode();\n```',
         );
     });
 

--- a/src/utils/previewer.ts
+++ b/src/utils/previewer.ts
@@ -52,7 +52,7 @@ function getTagBodyText(
         if (/^\s*[~`]{3}/m.test(text)) {
             return text;
         }
-        return '```\n' + text + '\n```';
+        return '```typescript\n' + text + '\n```';
     }
 
     const text = convertLinkTags(tag.text, filePathConverter);


### PR DESCRIPTION
When interpreting the preview result as Markdown, it is quite helpful to have the `typescript` language annotation before `@example` code blocks because it will give code highlights and make it more clear that this is an example of code rather than just raw text.