### PR TITLE
chore: set packageManager field to yarn@1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
     "vscode-uri": "^3.0.8",
     "which": "^4.0.0",
     "why-is-node-running": "^2.2.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "engines": {
     "node": ">=18"
   },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "files": [
     "lib"
   ],
@@ -76,6 +77,5 @@
     "vscode-uri": "^3.0.8",
     "which": "^4.0.0",
     "why-is-node-running": "^2.2.2"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
Set the packageManager field in the package.json file to `yarn@1` to make the development environment easier to reproduce.

Some tools, like corepack (and yarn itself?) will use this field to use the correct package manager version

https://yarnpkg.com/configuration/manifest#packageManager