### PR TITLE
style: set editorconfig indentation for yaml files to 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
+
+[*.{yaml,yml}]
+indent_size = 2


### PR DESCRIPTION
This matches the indentation in .github/workflows/*.yaml files