### PR TITLE
Tell client a completion item has code actions

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -109,6 +109,7 @@ function asCompletionItem(
         preselect: entry.isRecommended,
         data: {
             cacheId,
+            hasAction: entry.hasAction,
         },
     };
 


### PR DESCRIPTION
This will allow clients to better detect which completion item really needs to be resolved. This will help speed up clients such as Emacs' lsp-mode

https://github.com/emacs-lsp/lsp-mode/issues/4757