### PR TITLE
Add support for the "Move to file" interactive code action

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ The language server accepts various settings through the `initializationOptions`
 | hostInfo          | string   | Information about the host, for example `"Emacs 24.4"` or `"Sublime Text v3075"`. **Default**: `undefined` |
 | completionDisableFilterText  | boolean | Don't set `filterText` property on completion items. **Default**: `false` |
 | disableAutomaticTypingAcquisition | boolean | Disables tsserver from automatically fetching missing type definitions (`@types` packages) for external modules. |
+| supportsMoveToFileCodeAction | boolean | Whether the client supports the "Move to file" interactive code action. |
 | maxTsServerMemory | number   | The maximum size of the V8's old memory section in megabytes (for example `4096` means 4GB). The default value is dynamically configured by Node so can differ per system. Increase for very big projects that exceed allowed memory usage. **Default**: `undefined` |
 | npmLocation       | string   | Specifies the path to the NPM executable used for Automatic Type Acquisition. |
 | locale            | string   | The locale to use to show error messages. |

--- a/src/refactor.ts
+++ b/src/refactor.ts
@@ -18,9 +18,15 @@ export function provideRefactors(response: ts.server.protocol.GetApplicableRefac
         if (info.inlineable === false) {
             actions.push(asSelectRefactoring(info, args));
         } else {
-            const relevantActions = features.codeActionDisabledSupport
-                ? info.actions
-                : info.actions.filter(action => !action.notApplicableReason);
+            const relevantActions = info.actions.filter(action => {
+                if (action.notApplicableReason && !features.codeActionDisabledSupport) {
+                    return false;
+                }
+                if (action.isInteractive && (!features.moveToFileCodeActionSupport || action.name !== 'Move to file')) {
+                    return false;
+                }
+                return true;
+            });
             for (const action of relevantActions) {
                 actions.push(asApplyRefactoring(action, info, args));
             }

--- a/src/ts-protocol.ts
+++ b/src/ts-protocol.ts
@@ -352,6 +352,7 @@ export interface SupportedFeatures {
     definitionLinkSupport?: boolean;
     diagnosticsSupport?: boolean;
     diagnosticsTagSupport?: boolean;
+    moveToFileCodeActionSupport?: boolean;
 }
 
 export interface TypeScriptPlugin {
@@ -363,6 +364,7 @@ export interface TypeScriptPlugin {
 export interface TypeScriptInitializationOptions {
     completionDisableFilterText?: boolean;
     disableAutomaticTypingAcquisition?: boolean;
+    supportsMoveToFileCodeAction?: boolean;
     hostInfo?: string;
     locale?: string;
     maxTsServerMemory?: number;


### PR DESCRIPTION
This adds support for the "Move to file" code action, fixing #863.

This pull request does the following:
- adds a `supportsMoveToFileCodeAction` initialization option so that the change is opt-in
- this initialization option is then stored in a `moveToFileCodeActionSupport` flag in `features`
- sets the `includeInteractiveCodeActions` flag to `true` in `getRefactors`, provided that the client does support the "Move to file" code action
- filters out potential other interactive code actions in `provideRefactors` (as there could be other interactive code actions that would require separate opt-in)
- throws an error in case applying a code action results in a body containing `notApplicableReason` (this is specific to interactive code actions as for instance "Move to file" may fail if you provide an invalid file name, which is only known when applying the code action).