### PR TITLE
Doc config: maximumHoverLength required typescript 5.9+

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ Specifies preferences for the internal `tsserver` process. Those options depend 
 
 **lazyConfiguredProjectsFromExternalProject** [boolean] **Default**: `false`
 
-**maximumHoverLength** [number] A positive integer indicating the maximum length of a hover text before it is truncated. **Default**: `500`. Since TypeScript 5.9+.
+**maximumHoverLength** [number] A positive integer indicating the maximum length of a hover text before it is truncated. Since TypeScript 5.9+. **Default**: `500`.
 
 <a name="organizeImportsIgnoreCase"></a> **organizeImportsIgnoreCase** [string or boolean] Indicates whether imports should be organized in a case-insensitive manner. Supported values: `'auto'`, `boolean`. **Default**: `'auto'`
 


### PR DESCRIPTION
It only works from TypeScript 5.9+; I didn't know that and struggled a bit not knowing why this option wasn't working. I realized it when I saw this line from the VS Code repository:

https://github.com/microsoft/vscode/blob/5f881010a0871ab02c145eac646397a8d78ac3a7/extensions/typescript-language-features/package.nls.json#L229