### PR TITLE
refactor: don't send "configure" request during completion resolve

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -584,7 +584,6 @@ export class LspServer {
                 const uri = this.tsClient.toResourceUri(cachedData.file);
                 document = this.tsClient.toOpenDocument(uri);
                 if (document) {
-                    await this.fileConfigurationManager.ensureConfigurationForDocument(document, token);
                     const response = await this.tsClient.interruptGetErr(() => this.tsClient.execute(CommandTypes.CompletionDetails, cachedData, token));
                     if (response.type !== 'response' || !response.body?.length) {
                         return item;


### PR DESCRIPTION
This request seems unnecessary because the `completion` handler already configures the document.

When this was added in https://github.com/typescript-language-server/typescript-language-server/pull/377 the `completion` handler didn't actually trigger `configure` request but now it does so it should do the job.