### PR TITLE
fix: announce all supported commands

### DIFF
--- a/src/commands/commandManager.ts
+++ b/src/commands/commandManager.ts
@@ -30,6 +30,10 @@ export class CommandManager {
         }
     }
 
+    public get registeredIds(): string[] {
+        return Array.from(this.commands.keys());
+    }
+
     public async handle(commandId: Command['id'], ...args: unknown[]): Promise<boolean> {
         const entry = this.commands.get(commandId);
         if (entry) {

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -223,6 +223,7 @@ export class LspServer {
                         Commands.APPLY_RENAME_FILE,
                         Commands.SOURCE_DEFINITION,
                         Commands.TS_SERVER_REQUEST,
+                        ...this.commandManager.registeredIds,
                     ],
                 },
                 hoverProvider: true,


### PR DESCRIPTION
Zed filters out code actions if those use commands that the server doesn't advertise support for so make sure that server does announce those.

Fixes #1052