### PR TITLE
fix: don't send duplicate refactors when more than one context.only

### DIFF
--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -849,8 +849,8 @@ export class LspServer {
     }
 
     protected async getRefactors(fileRangeArgs: ts.server.protocol.FileRangeRequestArgs, context: lsp.CodeActionContext, features: SupportedFeatures, token?: lsp.CancellationToken): Promise<ts.server.protocol.ApplicableRefactorInfo[]> {
-        // Make separate request for each "kind" that was specified or a single request otherwise.
-        const kinds = context.only || [undefined];
+        // Make separate request for each refactor "kind" that was specified or a single request otherwise.
+        const kinds = (context.only || [undefined]).filter(kind => kind === undefined || CodeActionKind.Refactor.contains(new CodeActionKind(kind)));
 
         const responses = await Promise.all(kinds.map(async (kind) => {
             const args: ts.server.protocol.GetApplicableRefactorsRequestArgs = {


### PR DESCRIPTION
When client would send code action request with `only: ['source', 'refactor']` (for example), we would request refactors for each kind instead of only for `refactor`.