### PR TITLE
feat: add opt-in eager diagnostic clearing on didChange

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,6 +227,15 @@ completions.completeFunctionCalls: boolean;
 // See https://github.com/microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json for a full list of valid codes.
 diagnostics.ignoredCodes: number[];
 /**
+ * When enabled, diagnostics for a file are cleared immediately on each change,
+ * before fresh diagnostics arrive from tsserver. This prevents stale diagnostics
+ * from persisting between an edit and the subsequent reanalysis. Intended for
+ * non-UI rapid-edit workflows such as agentic coding tools.
+ *
+ * @default false
+ */
+diagnostics.eagerClear: boolean;
+/**
  * Enable/disable semantic checking of JavaScript files. Existing `jsconfig.json` or `tsconfig.json` files override this setting.
  *
  * @default false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,14 +226,7 @@ completions.completeFunctionCalls: boolean;
 // Diagnostics code to be omitted when reporting diagnostics.
 // See https://github.com/microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json for a full list of valid codes.
 diagnostics.ignoredCodes: number[];
-/**
- * When enabled, diagnostics for a file are cleared immediately on each change,
- * before fresh diagnostics arrive from tsserver. This prevents stale diagnostics
- * from persisting between an edit and the subsequent reanalysis. Intended for
- * non-UI rapid-edit workflows such as agentic coding tools.
- *
- * @default false
- */
+// Clear diagnostics immediately on each change to prevent stale diagnostics from persisting between edits. Default: false
 diagnostics.eagerClear: boolean;
 /**
  * Enable/disable semantic checking of JavaScript files. Existing `jsconfig.json` or `tsconfig.json` files override this setting.

--- a/src/diagnosticsManager.ts
+++ b/src/diagnosticsManager.ts
@@ -116,6 +116,26 @@ export class DiagnosticsManager {
     }
 
     /**
+     * Immediately publish empty diagnostics for a file. Used to clear stale diagnostics
+     * when a file changes, before fresh diagnostics arrive from tsserver.
+     */
+    public clearDiagnosticsForFile(file: string): void {
+        if (!this.features.diagnosticsSupport) {
+            return;
+        }
+        const uri = this.client.toResourceUri(file);
+        const diagnosticsForFile = this.diagnostics.get(uri);
+        if (diagnosticsForFile) {
+            // onDidClose clears per-kind state, publishes empty diagnostics,
+            // and sets closed=true to neutralize any pending debounced publish.
+            diagnosticsForFile.onDidClose();
+            this.diagnostics.delete(uri);
+        } else {
+            this.publishDiagnostics({ uri, diagnostics: [] });
+        }
+    }
+
+    /**
      * A testing function to clear existing file diagnostics, request fresh ones and wait for all to arrive.
      */
     public async waitForDiagnosticsForTesting(file: string): Promise<void> {

--- a/src/features/fileConfigurationManager.ts
+++ b/src/features/fileConfigurationManager.ts
@@ -126,6 +126,14 @@ export type TypeScriptInlayHintsPreferences = Pick<
 
 interface WorkspaceConfigurationDiagnosticsOptions {
     ignoredCodes?: number[];
+    /**
+     * When true, diagnostics for a file are cleared immediately when the file changes, before
+     * fresh diagnostics arrive from tsserver. This prevents stale diagnostics from persisting
+     * between an edit and the subsequent reanalysis.
+     *
+     * @default false
+     */
+    eagerClear?: boolean;
 }
 
 export interface WorkspaceConfigurationCompletionOptions {

--- a/src/lsp-server.test.ts
+++ b/src/lsp-server.test.ts
@@ -1038,6 +1038,68 @@ describe('editing', () => {
     });
 });
 
+describe('eager diagnostic invalidation', () => {
+    it('clears diagnostics synchronously on didChange when eagerClear is enabled', async () => {
+        server.updateWorkspaceSettings({ diagnostics: { eagerClear: true } });
+
+        const doc = {
+            uri: uri('eagerClearEnabled.ts'),
+            languageId: 'typescript',
+            version: 1,
+            // Type error: 'missing' is not defined.
+            text: `export function foo(): void { missing('test'); }`,
+        };
+
+        await openDocumentAndWaitForDiagnostics(server, doc);
+
+        // Confirm we have diagnostics before the change.
+        expect(diagnostics.get(doc.uri)?.diagnostics.length).toBeGreaterThan(0);
+
+        // Send a change - eagerClear should synchronously publish empty diagnostics.
+        server.didChangeTextDocument({
+            textDocument: { uri: doc.uri, version: 2 },
+            contentChanges: [{ text: `export function foo(): void {}` }],
+        });
+
+        // Synchronous check: diagnostics must be empty immediately after didChange returns.
+        const result = diagnostics.get(doc.uri);
+        expect(result).toBeDefined();
+        expect(result!.diagnostics).toHaveLength(0);
+
+        // Restore default settings so subsequent tests are unaffected.
+        server.updateWorkspaceSettings({ diagnostics: { eagerClear: false } });
+    });
+
+    it('does NOT clear diagnostics synchronously on didChange when eagerClear is disabled', async () => {
+        server.updateWorkspaceSettings({ diagnostics: { eagerClear: false } });
+
+        const doc = {
+            uri: uri('eagerClearDisabled.ts'),
+            languageId: 'typescript',
+            version: 1,
+            // Type error: 'missing' is not defined.
+            text: `export function foo(): void { missing('test'); }`,
+        };
+
+        await openDocumentAndWaitForDiagnostics(server, doc);
+
+        // Confirm we have diagnostics before the change.
+        const before = diagnostics.get(doc.uri)?.diagnostics ?? [];
+        expect(before.length).toBeGreaterThan(0);
+
+        // Send a change - without eagerClear the diagnostics map should NOT be emptied synchronously.
+        server.didChangeTextDocument({
+            textDocument: { uri: doc.uri, version: 2 },
+            contentChanges: [{ text: `export function foo(): void {}` }],
+        });
+
+        // Synchronous check: the previous (non-empty) diagnostics should still be present.
+        const result = diagnostics.get(doc.uri);
+        expect(result).toBeDefined();
+        expect(result!.diagnostics.length).toBeGreaterThan(0);
+    });
+});
+
 describe('references', () => {
     it('respects "includeDeclaration" in the request', async () => {
         const doc = {

--- a/src/lsp-server.test.ts
+++ b/src/lsp-server.test.ts
@@ -1047,7 +1047,7 @@ describe('eager diagnostic invalidation', () => {
             languageId: 'typescript',
             version: 1,
             // Type error: 'missing' is not defined.
-            text: `export function foo(): void { missing('test'); }`,
+            text: 'export function foo(): void { missing(\'test\'); }',
         };
 
         await openDocumentAndWaitForDiagnostics(server, doc);
@@ -1058,7 +1058,7 @@ describe('eager diagnostic invalidation', () => {
         // Send a change - eagerClear should synchronously publish empty diagnostics.
         server.didChangeTextDocument({
             textDocument: { uri: doc.uri, version: 2 },
-            contentChanges: [{ text: `export function foo(): void {}` }],
+            contentChanges: [{ text: 'export function foo(): void {}' }],
         });
 
         // Synchronous check: diagnostics must be empty immediately after didChange returns.
@@ -1078,7 +1078,7 @@ describe('eager diagnostic invalidation', () => {
             languageId: 'typescript',
             version: 1,
             // Type error: 'missing' is not defined.
-            text: `export function foo(): void { missing('test'); }`,
+            text: 'export function foo(): void { missing(\'test\'); }',
         };
 
         await openDocumentAndWaitForDiagnostics(server, doc);
@@ -1090,7 +1090,7 @@ describe('eager diagnostic invalidation', () => {
         // Send a change - without eagerClear the diagnostics map should NOT be emptied synchronously.
         server.didChangeTextDocument({
             textDocument: { uri: doc.uri, version: 2 },
-            contentChanges: [{ text: `export function foo(): void {}` }],
+            contentChanges: [{ text: 'export function foo(): void {}' }],
         });
 
         // Synchronous check: the previous (non-empty) diagnostics should still be present.

--- a/src/lsp-server.ts
+++ b/src/lsp-server.ts
@@ -404,6 +404,12 @@ export class LspServer {
     }
 
     didChangeTextDocument(params: lsp.DidChangeTextDocumentParams): void {
+        if (this.fileConfigurationManager.workspaceConfiguration.diagnostics?.eagerClear) {
+            const document = this.tsClient.toOpenDocument(params.textDocument.uri);
+            if (document) {
+                this.diagnosticsManager.clearDiagnosticsForFile(document.filepath);
+            }
+        }
         this.tsClient.onDidChangeTextDocument(params);
     }
 


### PR DESCRIPTION
## Summary

Adds an opt-in `diagnostics.eagerClear` setting that publishes empty diagnostics for a file immediately when its content changes, before reanalysis completes.

## Motivation

LSP servers are optimized for interactive editors, where debouncing diagnostics reduces flicker while a human is typing. This default is sensible and should remain unchanged.

However, LSP is increasingly used by headless agentic tools (AI coding assistants, automated refactoring systems) that consume diagnostics programmatically. For these clients, stale diagnostics between an edit and reanalysis create incorrect input to decision loops, causing issues like:

- Re-fixing already fixed errors
- Missing newly introduced errors
- Looping on diagnostics that no longer apply

This is not a bug in the server - it is a difference in client requirements. Interactive editors benefit from stable UI during typing. Programmatic clients benefit from immediate staleness signals.

## Changes

- **New setting**: `diagnostics.eagerClear` (default: `false`)
  - When enabled, `textDocument/didChange` triggers an immediate publish of empty diagnostics for the changed file
  - Server continues normal debounced analysis pipeline
  - Fresh diagnostics arrive once tsserver reanalysis completes

- **Implementation**:
  - Adds `clearDiagnosticsForFile()` method to `DiagnosticsManager`
  - Reuses existing `onDidClose()` invalidation path to cancel pending debounced publishes before clearing
  - Hooks into `didChangeTextDocument` handler when setting is enabled

- **Tests**: Two new tests verify:
  - When enabled: diagnostics are cleared synchronously on `didChange`
  - When disabled: existing behavior preserved (no synchronous clear)

## Configuration

```json
{
  "diagnostics.eagerClear": false
}
```

Setting this to `true` is intended for non-UI rapid-edit workflows such as agentic coding tools.

## Test Plan

1. Run existing test suite to verify no regressions in default behavior
2. Run new tests (`yarn test:commit`) to verify eager clearing works when enabled
3. Manual verification in VS Code:
   - With setting disabled: observe normal debounced diagnostic updates
   - With setting enabled: observe immediate diagnostic clearing on edit

## Related Work

This is part of a coordinated effort across multiple LSP server ecosystems to support agentic workflows. See: https://github.com/lsp-eager-invalidation

Similar PRs:
- pyright (Python)
- rust-analyzer (Rust)
- gopls (Go)