### PR TITLE
docs: pinning TypeScript version to 6 in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently Microsoft is working on [TypeScript 7](https://github.com/microsoft/ty
 ## Installing
 
 ```sh
-npm install -g typescript-language-server typescript
+npm install -g typescript-language-server typescript@6
 ```
 
 ## Running the language server


### PR DESCRIPTION
It took me hours to finally find out that I had installed a too recent version of typescript.
This is going to save a lot of time to a lot of noobs.